### PR TITLE
Support cross-compilation from macOS for C++ and Java in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
+# Options common for all EngFlow remote configurations.
 build:engflow_common --jobs=8
 build:engflow_common --define=EXECUTOR=remote
 build:engflow_common --disk_cache=
@@ -8,6 +9,7 @@ build:engflow_common --remote_timeout=3600
 
 build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflow_common --crosstool_top=//remote_config/cc:toolchain
+build:engflow_common --cpu=k8
 build:engflow_common --extra_execution_platforms=//remote_config/config:platform
 build:engflow_common --extra_toolchains=//remote_config/config:cc-toolchain
 build:engflow_common --host_platform=//remote_config/config:platform
@@ -17,13 +19,20 @@ build:engflow_common --java_language_version=11
 
 build:without_bytes --experimental_remote_download_outputs=minimal
 
+# Options for a private EngFlow cluster.
+# - Change "10.0.0.10:8080" to the actual cluster IP and port.
+# - You'll also need to set flags for your authentication method.
+#   For example, if your cluster uses mTLS authentication, you could add
+#   the flags below (with correct paths), either here or in ~/.bazelrc:
+# build:engflow --tls_client_certificate=/path/to/client.crt
+# build:engflow --tls_client_key=/path/to/client.key
 build:engflow --config=engflow_common
 build:engflow --remote_executor=grpcs://10.0.0.10:8080
-build:engflow --tls_certificate=engflow-ca.crt
 build:engflow --bes_backend=grpcs://10.0.0.10:8080
 build:engflow --bes_lifecycle_events
 build:engflow --bes_results_url=https://10.0.0.10:8080/invocation/
 
+# Options for the open source cluster.
 build:engflow_oss --config=engflow_common
 build:engflow_oss --remote_executor=grpcs://oss-cluster.engflow.com
 build:engflow_oss --bes_backend=grpcs://oss-cluster.engflow.com

--- a/remote_config/cc/BUILD
+++ b/remote_config/cc/BUILD
@@ -15,7 +15,7 @@
 # This becomes the BUILD file for @local_config_cc// under non-BSD unixes.
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
-load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
+load(":stub_cc_toolchain_config.bzl", "stub_cc_toolchain_config")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 
 package(default_visibility = ["//visibility:public"])
@@ -54,6 +54,7 @@ cc_toolchain_suite(
         "k8": ":cc-compiler-k8",
         "armeabi-v7a|compiler": ":cc-compiler-armeabi-v7a",
         "armeabi-v7a": ":cc-compiler-armeabi-v7a",
+        "darwin_arm64": ":cc-compiler-darwin_arm64",
     },
 )
 
@@ -165,4 +166,27 @@ cc_toolchain(
     toolchain_identifier = "stub_armeabi-v7a",
 )
 
-armeabi_cc_toolchain_config(name = "stub_armeabi-v7a")
+stub_cc_toolchain_config(
+    name = "stub_armeabi-v7a",
+    cpu_name = "armeabi-v7a",
+)
+
+cc_toolchain(
+    name = "cc-compiler-darwin_arm64",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 1,
+    toolchain_config = ":stub_darwin_arm64",
+    toolchain_identifier = "stub_darwin_arm64",
+)
+
+stub_cc_toolchain_config(
+    name = "stub_darwin_arm64",
+    cpu_name = "darwin_arm64",
+)

--- a/remote_config/cc/stub_cc_toolchain_config.bzl
+++ b/remote_config/cc/stub_cc_toolchain_config.bzl
@@ -21,14 +21,14 @@ load(
 )
 
 def _impl(ctx):
-    toolchain_identifier = "stub_armeabi-v7a"
-    host_system_name = "armeabi-v7a"
-    target_system_name = "armeabi-v7a"
-    target_cpu = "armeabi-v7a"
-    target_libc = "armeabi-v7a"
+    toolchain_identifier = "stub_" + ctx.attr.cpu_name
+    host_system_name = ctx.attr.cpu_name
+    target_system_name = ctx.attr.cpu_name
+    target_cpu = ctx.attr.cpu_name
+    target_libc = ctx.attr.cpu_name
     compiler = "compiler"
-    abi_version = "armeabi-v7a"
-    abi_libc_version = "armeabi-v7a"
+    abi_version = ctx.attr.cpu_name
+    abi_libc_version = ctx.attr.cpu_name
     cc_target_os = None
     builtin_sysroot = None
     action_configs = []
@@ -41,18 +41,19 @@ def _impl(ctx):
     artifact_name_patterns = []
     make_variables = []
 
+    stub_tool_name = "/DONOTUSE/stub/" + ctx.attr.cpu_name
     tool_paths = [
-        tool_path(name = "ar", path = "/bin/false"),
-        tool_path(name = "compat-ld", path = "/bin/false"),
-        tool_path(name = "cpp", path = "/bin/false"),
-        tool_path(name = "dwp", path = "/bin/false"),
-        tool_path(name = "gcc", path = "/bin/false"),
-        tool_path(name = "gcov", path = "/bin/false"),
-        tool_path(name = "ld", path = "/bin/false"),
-        tool_path(name = "nm", path = "/bin/false"),
-        tool_path(name = "objcopy", path = "/bin/false"),
-        tool_path(name = "objdump", path = "/bin/false"),
-        tool_path(name = "strip", path = "/bin/false"),
+        tool_path(name = "ar", path = stub_tool_name),
+        tool_path(name = "compat-ld", path = stub_tool_name),
+        tool_path(name = "cpp", path = stub_tool_name),
+        tool_path(name = "dwp", path = stub_tool_name),
+        tool_path(name = "gcc", path = stub_tool_name),
+        tool_path(name = "gcov", path = stub_tool_name),
+        tool_path(name = "ld", path = stub_tool_name),
+        tool_path(name = "nm", path = stub_tool_name),
+        tool_path(name = "objcopy", path = stub_tool_name),
+        tool_path(name = "objdump", path = stub_tool_name),
+        tool_path(name = "strip", path = stub_tool_name),
     ]
 
     return cc_common.create_cc_toolchain_config_info(
@@ -75,8 +76,10 @@ def _impl(ctx):
         cc_target_os = cc_target_os,
     )
 
-armeabi_cc_toolchain_config = rule(
+stub_cc_toolchain_config = rule(
     implementation = _impl,
-    attrs = {},
+    attrs = {
+        "cpu_name": attr.string(mandatory = True),
+    },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
- In .bazelrc:
  - Add --cpu=k8. Without this, Bazel tries to select darwin_arm64 (or whatever
    the native platform is). This is still needed because Bazel still doesn't
    fully support platforms and toolchains for C++.
  - Add comments explaining what's missing and what to change.
  - Remove --tls_certificate. Bazel reports an error if it's used.
    (Should engflow-ca.crt be removed, too?)
- In //remote_config/cc:
  - Generalize armeabi_cc_toolchain_config to stub_cc_toolchain_config
    and declare a stub for darwin_arm64. This shouldn't be needed in theory,
    and C++ targets build without it, but Java targets need it. More stubs
    may be needed for --cpu values on other platforms.
  - Run buildifier on BUILD.
