### PR TITLE
Changed macos runner from 10.15 (deprecated) to 11 (latest)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
     steps:
     - uses: actions/checkout@v2
     - name: build everything


### PR DESCRIPTION
Because of https://github.com/EngFlow/example/issues/38