### PR TITLE
Remove globs from Java example

### DIFF
--- a/java/com/engflow/example/BUILD
+++ b/java/com/engflow/example/BUILD
@@ -2,11 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "example",
-    srcs = glob(["Example.java"]),
+    srcs = ["Example.java"],
 )
 
 java_test(
     name = "ExampleTest",
-    srcs = glob(["ExampleTest.java"]),
+    srcs = ["ExampleTest.java"],
     deps = [":example"],
 )


### PR DESCRIPTION
No wildcard, so no need for glob.
