### PR TITLE
Added support for csharp and hello world example

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
+build --enable_platform_specific_config
 # Options common for all EngFlow remote configurations.
 build:engflow_common --jobs=8
 build:engflow_common --define=EXECUTOR=remote
@@ -6,7 +7,6 @@ build:engflow_common --experimental_inmemory_dotd_files
 build:engflow_common --experimental_inmemory_jdeps_files
 build:engflow_common --incompatible_strict_action_env=true
 build:engflow_common --remote_timeout=3600
-build --enable_platform_specific_config
 
 build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflow_common --crosstool_top=//remote_config/cc:toolchain

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ build:engflow_common --experimental_inmemory_dotd_files
 build:engflow_common --experimental_inmemory_jdeps_files
 build:engflow_common --incompatible_strict_action_env=true
 build:engflow_common --remote_timeout=3600
+build:engflow_common --enable_platform_specific_config
 
 build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflow_common --crosstool_top=//remote_config/cc:toolchain
@@ -16,6 +17,11 @@ build:engflow_common --host_platform=//remote_config/config:platform
 build:engflow_common --platforms=//remote_config/config:platform
 build:engflow_common --java_runtime_version=remotejdk_11
 build:engflow_common --java_language_version=11
+
+build:macos --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100
+build:macos --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100
+build:linux --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100
+build:linux --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100
 
 build:without_bytes --experimental_remote_download_outputs=minimal
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,7 @@ build:engflow_common --experimental_inmemory_dotd_files
 build:engflow_common --experimental_inmemory_jdeps_files
 build:engflow_common --incompatible_strict_action_env=true
 build:engflow_common --remote_timeout=3600
-build:engflow_common --enable_platform_specific_config
+build --enable_platform_specific_config
 
 build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflow_common --crosstool_top=//remote_config/cc:toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,16 +54,8 @@ jobs:
 
     - name: Building //csharp directory (Linux)
       if: runner.os == 'Linux'
-      run: |
-        bazel build \
-        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 \
-        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 \
-        //csharp/...
+      run: bazel build //csharp/... --config=linux
 
     - name: Building //csharp directory (macOS)
       if: runner.os == 'macOS'
-      run: |
-        bazel build \
-        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 \
-        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 \
-        //csharp/...
+      run: bazel build //csharp/... --config=macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,3 +51,10 @@ jobs:
       run: |
         bazel build //typescript/...
         bazel test //typescript/...
+
+    - name: Building //csharp directory
+      run: |
+        bazel build \
+        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
+        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
+        //csharp/...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,18 @@ jobs:
         bazel build //typescript/...
         bazel test //typescript/...
 
-    - name: Building //csharp directory
+    - name: Building //csharp directory (Linux)
+      if: runner.os == 'Linux'
       run: |
         bazel build \
         --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
         --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
+        //csharp/...
+
+    - name: Building //csharp directory (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        bazel build \
+        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.407 \
+        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.407 \
         //csharp/...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,5 @@ jobs:
         bazel build //typescript/...
         bazel test //typescript/...
 
-    - name: Building //csharp directory (Linux)
-      if: runner.os == 'Linux'
-      run: bazel build //csharp/... --config=linux
-
-    - name: Building //csharp directory (macOS)
-      if: runner.os == 'macOS'
-      run: bazel build //csharp/... --config=macos
+    - name: Building //csharp directory
+      run: bazel build //csharp/...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,14 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         bazel build \
-        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
-        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.407 \
+        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 \
+        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 \
         //csharp/...
 
     - name: Building //csharp directory (macOS)
       if: runner.os == 'macOS'
       run: |
         bazel build \
-        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.407 \
-        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.407 \
+        --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 \
+        --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 \
         //csharp/...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,3 +203,23 @@ nodejs_register_toolchains(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+      name = "io_bazel_rules_dotnet",
+      remote = "https://github.com/bazelbuild/rules_dotnet",
+      branch = "master",
+)
+
+load("@io_bazel_rules_dotnet//dotnet:deps.bzl", "dotnet_repositories")
+
+dotnet_repositories()
+
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "dotnet_register_toolchains", "dotnet_repositories_nugets")
+
+dotnet_register_toolchains()
+
+dotnet_repositories_nugets()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -207,9 +207,9 @@ bazel_skylib_workspace()
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-      name = "io_bazel_rules_dotnet",
-      remote = "https://github.com/bazelbuild/rules_dotnet",
-      branch = "master",
+    name = "io_bazel_rules_dotnet",
+    commit = "0b7ae93fa81b7327a655118da0581db5ebbe0b8d",
+    remote = "https://github.com/bazelbuild/rules_dotnet",
 )
 
 load("@io_bazel_rules_dotnet//dotnet:deps.bzl", "dotnet_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -204,12 +204,11 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
+http_archive(
     name = "io_bazel_rules_dotnet",
-    commit = "0b7ae93fa81b7327a655118da0581db5ebbe0b8d",
-    remote = "https://github.com/bazelbuild/rules_dotnet",
+    sha256 = "400416de5d5d321fa7ca9e46110373cd39db7ed84ef3a61e1150c5813cb1c99e",
+    strip_prefix = "rules_dotnet-0.0.7",
+    urls = ["https://github.com/bazelbuild/rules_dotnet/archive/refs/tags/0.0.7.zip"],
 )
 
 load("@io_bazel_rules_dotnet//dotnet:deps.bzl", "dotnet_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -221,5 +221,3 @@ load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "dotnet_register_toolchains", "d
 dotnet_register_toolchains()
 
 dotnet_repositories_nugets()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/csharp/BUILD
+++ b/csharp/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "csharp_binary")
+
+csharp_binary(
+    name = "csharp.exe",
+    srcs = [
+        "Main.cs",
+    ],
+    deps = [
+        "@core_sdk_stdlib//:libraryset",
+    ],
+)

--- a/csharp/Main.cs
+++ b/csharp/Main.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace HelloWorld
+{
+    class Hello {
+        static void Main(string[] args)
+        {
+            System.Console.WriteLine("Hello World!");
+        }
+    }
+}


### PR DESCRIPTION
# About

Adding csharp support and hello world example. 
Run with
 
**Linux**
```sh
bazel build --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100 //csharp/...
```

**MacOS**
```sh
bazel build --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100 //csharp/...
```

Progress https://github.com/EngFlow/example/issues/36