### PR TITLE
Adding renovate workflow for automatic deps update

### DIFF
--- a/.github/renovate.yml
+++ b/.github/renovate.yml
@@ -15,4 +15,4 @@ jobs:
         env:
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.ANDRES_REENOVATE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/renovate.yml
+++ b/.github/renovate.yml
@@ -1,0 +1,18 @@
+name: Renovate Dependency Update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1" # Run every monday at midday
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+      - name: Renovate Update
+        uses: renovatebot/github-action@v34.146.1
+        env:
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.ANDRES_REENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,8 @@
 name: Renovate Dependency Update
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 12 * * 1" # Run every monday at midday
+  # schedule:
+  #  - cron: "0 12 * * 1" # Run every monday at midday
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: Renovate Update
         uses: renovatebot/github-action@v34.146.1
-        env:
         with:
           configurationFile: renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:base"
+    ],
+    "username": "engflow-github-automation",
+    "gitAuthor": "engflow-github-automation <support@engflow.com>",
+    "onboarding": false,
+    "enabledManagers": ["bazel", "npm"],
+    "vulnerabilityAlerts": {
+      "enabled": true
+    },
+    "platform": "github",
+    "repositories": [
+      "EngFlow/example"
+    ],
+    "reviewers": ["anfelbar", "jayconrod", "benjaminp", "afrueda97"]
+  }


### PR DESCRIPTION
# About

The workflow only has `workflow_dispatch` but I plan to use the commented line as well for `schedule`. I am not adding a new secret in the repository as it is a security issue (anybody could use it). I am using normal `GITHUB_TOKEN` that should work given that the repo is piublic. Right now activating updates for `bazel` and `npm`.