### PR TITLE
[ci] Switch to `pull_request_target`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - "main"
+  # TODO(yannic): Remove after merging https://github.com/EngFlow/example/pull/119.
+  pull_request:
+    branches:
+      - "main"
   pull_request_target:
     branches:
       - "main"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
-    tags: "v*"
-  pull_request:
-    branches: [main]
+    branches:
+      - "main"
+  pull_request_target:
+    branches:
+      - "main"
 
 # Recommended here: https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
 env:


### PR DESCRIPTION
The docs [1] seem to indicate that we can read secrets from `pull_request_target`, which we could use to get authentication tokens for RE.

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target