### PR TITLE
Reverting typescript update

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "typescript": "5.0.2"
+    "typescript": "4.9.5"
   }
-}  
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1,15 +1,17 @@
 lockfileVersion: 5.4
 
 specifiers:
-  typescript: 5.0.2
+  typescript: 4.9.5
 
 dependencies:
-  typescript: 5.0.2
+  typescript: 4.9.5
 
 packages:
-
-  /typescript/5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
+  /typescript/4.9.5:
+    resolution:
+      {
+        integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==,
+      }
+    engines: { node: ">=4.2.0" }
     hasBin: true
     dev: false


### PR DESCRIPTION
# About

With the latest version we get this (locally and in github runners): 

```sh
ERROR: An error occurred during the fetch of repository 'npm_typescript':
   Traceback (most recent call last):
        File "/home/andres/.cache/bazel/_bazel_andres/3d5b4782dbb193b9df57e427c9279258/external/aspect_rules_ts/ts/private/npm_repositories.bzl", line 35, column 13, in _http_archive_version_impl
                fail("""typescript version {} is not mirrored in rules_ts, is this a real version?
Error in fail: typescript version 5.0.2 is not mirrored in rules_ts, is this a real version?
```

# Note

I tried to revert this two days ago. My changes were not working and I think the reason is a general `github actions` failure that started several days ago: https://www.githubstatus.com/history