### PR TITLE
Bazelrc: fix macos/arm64 toolchain flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,9 +18,8 @@ build:engflow_common --platforms=//remote_config/config:platform
 build:engflow_common --java_runtime_version=remotejdk_11
 build:engflow_common --java_language_version=11
 
-build:macos --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100
 build:macos --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_amd64_3.1.100
-build:linux --host_platform @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100
+build:macos --platforms @io_bazel_rules_dotnet//dotnet/toolchain:darwin_arm64_6.0.101
 build:linux --platforms @io_bazel_rules_dotnet//dotnet/toolchain:linux_amd64_3.1.100
 
 build:clang --client_env=CC=clang


### PR DESCRIPTION
Q&A:
- What's the motivation? https://engflow.slack.com/archives/C01CPGQQ87N/p1680695117618029
- Is it fine to remove --host_platform? Yes it is, Bazel detects that automatically. There can be only one host platform anyway, whereas multiple target platforms may be specified.
- Why use a newer version than the others? Because there is no 3.1.100 for this OS/platform.
- Why not update the other versions? Because I don't need to and I'm not sure what it causes.