### PR TITLE
Tagging swift as manual (because of its clang flag)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,4 +63,4 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
 
       - name: Testing //swift directory
-        run: bazel test --config=clang //swift/...
+        run: bazel test --config=clang //swift:tests

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -6,4 +6,5 @@ swift_test(
         "example.swift",
         "main.swift",
     ],
+    tags = ["manual"],
 )

--- a/typescript/BUILD
+++ b/typescript/BUILD
@@ -5,7 +5,7 @@ ts_project(
     name = "typescript",
     srcs = ["main.ts"],
     declaration = True,
-    out_dir = "."
+    out_dir = ".",
 )
 
 build_test(


### PR DESCRIPTION
- Because it need `--config=clang` too, making `bazel build //...` fail
- Also formatted typescript `BUILD` file.