### PR TITLE
linux_x64: provide example Dockerfile

### DIFF
--- a/platform/linux_x64/docker/Dockerfile
+++ b/platform/linux_x64/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:latest
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN groupadd \
+  --gid 114 \
+  engflow && \
+  useradd \
+  --home-dir /home/engflow \
+  --create-home \
+  --uid 108 \
+  --gid 114 \
+  engflow
+ENV HOME=/home/engflow
+
+RUN apt-get update --quiet --quiet --yes && \
+  apt-get install --quiet --quiet --fix-broken --yes \
+  clang \
+  curl \
+  python3 \
+  python-is-python3 \
+  zip && \
+  rm -rf /var/lib/apt/lists/*

--- a/platform/linux_x64/docker/README.md
+++ b/platform/linux_x64/docker/README.md
@@ -1,0 +1,3 @@
+This directory contains a minimal Dockerfile you can use to build a container image to be used with remote execution.
+
+See https://docs.engflow.com/re/client/create-container.html for a complete explanation on what tools should be installed in a container image, where the image should be stored, and how to configure Bazel to use your image.


### PR DESCRIPTION
And link back to public documentation, when it exists.

For linear/CUS-64
