### PR TITLE
.bazelrc: fix redundancy that caused a Bazel crash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,6 @@ build:opal --config=opal_bes
 build:opal --config=opal_auth
 build:opal --remote_executor=grpcs://opal.cluster.engflow.com
 
-build:opal_bes --config=opal_auth
 build:opal_bes --bes_backend=grpcs://opal.cluster.engflow.com
 build:opal_bes --bes_lifecycle_events
 build:opal_bes --bes_results_url=https://opal.cluster.engflow.com/invocation/
@@ -79,7 +78,6 @@ build:magnesite --config=magnesite_bes
 build:magnesite --config=magnesite_auth
 build:magnesite --remote_executor=grpcs://magnesite.cluster.engflow.com
 
-build:magnesite_bes --config=magnesite_auth
 build:magnesite_bes --bes_backend=grpcs://magnesite.cluster.engflow.com
 build:magnesite_bes --bes_lifecycle_events
 build:magnesite_bes --bes_results_url=https://magnesite.cluster.engflow.com/invocation/

--- a/infra/test-all.py
+++ b/infra/test-all.py
@@ -21,6 +21,7 @@ def main():
         flags += [
             "--platforms=//platform/" + os_arch,
             "--config=opal_bes",
+            "--config=opal_auth",
         ]
 
     targets = [


### PR DESCRIPTION
Not really sure why, but specifying JWT authentication flags multiple times
causes Bazel to crash with no output, exit code 37.

Remove the redundant --config=opal_auth from the opal_bes and magnesite_bes
configurations. Add to test-all.py when remote execution is disabled.

I think we don't see this in CI because credential helper flags are safe
to specify more than once but --remote_header is not.

For linear/PE-2268
