### PR TITLE
go: upgrade Go, rules_go, and enable VSCode Go editor support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  "go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/go_sdk",
+  "go.toolsEnvVars": {
+    "GOPACKAGESDRIVER": "${workspaceFolder}/infra/gopackagesdriver.sh"
+  },
+  "go.enableCodeLens": {
+    "runtest": false
+  },
+  "gopls": {
+    "build.directoryFilters": [
+      "-bazel-bin",
+      "-bazel-out",
+      "-bazel-testlogs",
+      "-bazel-mypkg",
+    ],
+    "formatting.gofumpt": true,
+    "formatting.local": "github.com/my/mypkg",
+    "ui.completion.usePlaceholders": true,
+    "ui.semanticTokens": true,
+    "ui.codelenses": {
+      "gc_details": false,
+      "regenerate_cgo": false,
+      "generate": false,
+      "test": false,
+      "tidy": false,
+      "upgrade_dependency": false,
+      "vendor": false
+    },
+  },
+  "go.useLanguageServer": true,
+  "go.buildOnSave": "off",
+  "go.lintOnSave": "off",
+  "go.vetOnSave": "off",
+}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,7 @@ http_archive(
     urls = [
         "https://github.com/EngFlow/engflowapis/archive/9ab1928c36ec91e621ceaf488719f0df664148a0.zip",
     ],
-) 
+)
 
 http_archive(
     name = "io_grpc_grpc_java",
@@ -81,9 +81,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
+    sha256 = "c8035e8ae248b56040a65ad3f0b7434712e2037e5dfdcebfe97576e620422709",
     urls = [
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.44.0/rules_go-v0.44.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.44.0/rules_go-v0.44.0.zip",
     ],
 )
 
@@ -211,7 +212,7 @@ go_dependencies()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.21.2")
+go_register_toolchains(version = "1.21.5")
 
 gazelle_dependencies()
 

--- a/go/main.go
+++ b/go/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println("hello world")
+	fmt.Println("hello world")
 }

--- a/infra/gopackagesdriver.sh
+++ b/infra/gopackagesdriver.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
Following instructions at
https://github.com/bazelbuild/rules_go/wiki/Editor-setuphttps://github.com/bazelbuild/rules_go/wiki/Editor-setup
