### PR TITLE
[windows] Enabling dev mode in docker

### DIFF
--- a/platform/windows_x64/docker/normalize_os_windows.ps1
+++ b/platform/windows_x64/docker/normalize_os_windows.ps1
@@ -12,3 +12,11 @@ Set-StrictMode -Version latest
 # This directory is removed below after reboot.
 New-Item -Type Directory -Path "${env:EF_INSTALL_TEMP_DIR}"
 
+# Enable developer mode. This is needed so that the worker service can create symbolic links.
+# Adapted from https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging#use-powershell-to-enable-your-device
+New-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" `
+    -Name "AllowDevelopmentWithoutDevLicense" `
+    -Value 1 `
+    -PropertyType DWORD `
+    -Force


### PR DESCRIPTION
# About

- Towards CUS-227
- Added script according to the [ticket description](https://linear.app/engflow/issue/CUS-227/windows-ci-cant-create-symbolic-links-in-docker-actions) 
- Built the docker image in `gcp` windows dev machine
- Logged into docker aws and pushed the image (see [glass](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/645088952840/engflow-re/windows-x64?region=eu-west-1))
