### PR TITLE
Bump to rules_go 0.47.1, Go 1.22.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -91,30 +91,13 @@ use_repo(dotnet, "dotnet_toolchains")
 register_toolchains("@dotnet_toolchains//:all")
 
 # https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
-bazel_dep(name = "rules_go", version = "0.46.0")
+bazel_dep(name = "rules_go", version = "0.47.1")
 bazel_dep(name = "gazelle", version = "0.36.0")
 
-GO_PLATFORMS = [
-    ("darwin", "amd64"),
-    ("darwin", "arm64"),
-    ("linux", "amd64"),
-    ("linux", "arm64"),
-    ("windows", "amd64"),
-]
-
-GO_VERSION = "1.21.6"
+GO_VERSION = "1.22.3"
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-
-[
-    go_sdk.download(
-        name = "go_{}_{}".format(goos, goarch),
-        goarch = goarch,
-        goos = goos,
-        version = GO_VERSION,
-    )
-    for goos, goarch in GO_PLATFORMS
-]
+go_sdk.download(version = GO_VERSION)
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "5d8746a319cb1531495c687f9ff106b7846176c8a473f3aab1787e7eea660b85",
+  "moduleFileHash": "4ba843ac010cef908a3f301602e131ffd6b43c757201682bd4afda9d8a925c18",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -183,7 +183,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 107,
+            "line": 99,
             "column": 23
           },
           "imports": {},
@@ -192,76 +192,13 @@
             {
               "tagName": "download",
               "attributeValues": {
-                "name": "go_darwin_amd64",
-                "goarch": "amd64",
-                "goos": "darwin",
-                "version": "1.21.6"
+                "version": "1.22.3"
               },
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 110,
-                "column": 20
-              }
-            },
-            {
-              "tagName": "download",
-              "attributeValues": {
-                "name": "go_darwin_arm64",
-                "goarch": "arm64",
-                "goos": "darwin",
-                "version": "1.21.6"
-              },
-              "devDependency": false,
-              "location": {
-                "file": "@@//:MODULE.bazel",
-                "line": 110,
-                "column": 20
-              }
-            },
-            {
-              "tagName": "download",
-              "attributeValues": {
-                "name": "go_linux_amd64",
-                "goarch": "amd64",
-                "goos": "linux",
-                "version": "1.21.6"
-              },
-              "devDependency": false,
-              "location": {
-                "file": "@@//:MODULE.bazel",
-                "line": 110,
-                "column": 20
-              }
-            },
-            {
-              "tagName": "download",
-              "attributeValues": {
-                "name": "go_linux_arm64",
-                "goarch": "arm64",
-                "goos": "linux",
-                "version": "1.21.6"
-              },
-              "devDependency": false,
-              "location": {
-                "file": "@@//:MODULE.bazel",
-                "line": 110,
-                "column": 20
-              }
-            },
-            {
-              "tagName": "download",
-              "attributeValues": {
-                "name": "go_windows_amd64",
-                "goarch": "amd64",
-                "goos": "windows",
-                "version": "1.21.6"
-              },
-              "devDependency": false,
-              "location": {
-                "file": "@@//:MODULE.bazel",
-                "line": 110,
-                "column": 20
+                "line": 100,
+                "column": 16
               }
             }
           ],
@@ -274,7 +211,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 119,
+            "line": 102,
             "column": 24
           },
           "imports": {
@@ -290,7 +227,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 120,
+                "line": 103,
                 "column": 18
               }
             }
@@ -304,7 +241,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 137,
+            "line": 120,
             "column": 22
           },
           "imports": {
@@ -328,7 +265,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 138,
+                "line": 121,
                 "column": 14
               }
             }
@@ -342,7 +279,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 162,
+            "line": 145,
             "column": 29
           },
           "imports": {
@@ -358,7 +295,7 @@
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 168,
+                "line": 151,
                 "column": 18
               }
             }
@@ -375,7 +312,7 @@
         "rules_proto": "rules_proto@6.0.0-rc2",
         "build_bazel_apple_support": "apple_support@1.15.1",
         "rules_dotnet": "rules_dotnet@0.15.1",
-        "rules_go": "rules_go@0.46.0",
+        "rules_go": "rules_go@0.47.1",
         "gazelle": "gazelle@0.36.0",
         "rules_java": "rules_java@7.5.0",
         "rules_jvm_external": "rules_jvm_external@6.0",
@@ -571,7 +508,7 @@
         "com_github_grpc_grpc": "grpc@1.56.3.bcr.1",
         "io_grpc_grpc_java": "grpc-java@1.62.2",
         "com_google_protobuf": "protobuf@23.1",
-        "io_bazel_rules_go": "rules_go@0.46.0",
+        "io_bazel_rules_go": "rules_go@0.47.1",
         "rules_proto": "rules_proto@6.0.0-rc2",
         "rules_python": "rules_python@0.31.0",
         "bazel_tools": "bazel_tools@_",
@@ -933,10 +870,10 @@
         }
       }
     },
-    "rules_go@0.46.0": {
+    "rules_go@0.47.1": {
       "name": "rules_go",
-      "version": "0.46.0",
-      "key": "rules_go@0.46.0",
+      "version": "0.47.1",
+      "key": "rules_go@0.47.1",
       "repoName": "io_bazel_rules_go",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [
@@ -946,9 +883,9 @@
         {
           "extensionBzlFile": "@io_bazel_rules_go//go:extensions.bzl",
           "extensionName": "go_sdk",
-          "usingModule": "rules_go@0.46.0",
+          "usingModule": "rules_go@0.47.1",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_go/0.47.1/MODULE.bazel",
             "line": 16,
             "column": 23
           },
@@ -962,11 +899,11 @@
               "tagName": "download",
               "attributeValues": {
                 "name": "go_default_sdk",
-                "version": "1.21.1"
+                "version": "1.21.8"
               },
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/rules_go/0.47.1/MODULE.bazel",
                 "line": 17,
                 "column": 16
               }
@@ -978,9 +915,9 @@
         {
           "extensionBzlFile": "@gazelle//:extensions.bzl",
           "extensionName": "go_deps",
-          "usingModule": "rules_go@0.46.0",
+          "usingModule": "rules_go@0.47.1",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_go/0.47.1/MODULE.bazel",
             "line": 32,
             "column": 24
           },
@@ -993,7 +930,8 @@
             "org_golang_google_grpc_cmd_protoc_gen_go_grpc": "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
             "org_golang_google_protobuf": "org_golang_google_protobuf",
             "org_golang_x_net": "org_golang_x_net",
-            "org_golang_x_tools": "org_golang_x_tools"
+            "org_golang_x_tools": "org_golang_x_tools",
+            "bazel_gazelle_go_repository_config": "bazel_gazelle_go_repository_config"
           },
           "devImports": [],
           "tags": [
@@ -1004,7 +942,7 @@
               },
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/rules_go/0.47.1/MODULE.bazel",
                 "line": 33,
                 "column": 18
               }
@@ -1029,9 +967,9 @@
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.47.1/rules_go-v0.47.1.zip"
           ],
-          "integrity": "sha256-gKmCd60TEdrNg3+bFttiiHcC6fHRxMn3ltASGkbI4YQ=",
+          "integrity": "sha256-90yY1t9VIXo2hZx0tGDndKvAQQpHzBANgivjTV+ZDxY=",
           "strip_prefix": "",
           "remote_patches": {},
           "remote_patch_strip": 0
@@ -1142,7 +1080,7 @@
         "bazel_features": "bazel_features@1.9.1",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "com_google_protobuf": "protobuf@23.1",
-        "io_bazel_rules_go": "rules_go@0.46.0",
+        "io_bazel_rules_go": "rules_go@0.47.1",
         "rules_proto": "rules_proto@6.0.0-rc2",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -2065,7 +2003,7 @@
         "com_github_grpc_grpc": "grpc@1.56.3.bcr.1",
         "com_google_protobuf": "protobuf@23.1",
         "rules_cc": "rules_cc@0.0.9",
-        "io_bazel_rules_go": "rules_go@0.46.0",
+        "io_bazel_rules_go": "rules_go@0.47.1",
         "rules_jvm_external": "rules_jvm_external@6.0",
         "rules_proto": "rules_proto@6.0.0-rc2",
         "bazel_tools": "bazel_tools@_",
@@ -3053,7 +2991,7 @@
         "upb": "upb@0.0.0-20230516-61a97ef",
         "zlib": "zlib@1.3",
         "rules_java": "rules_java@7.5.0",
-        "io_bazel_rules_go": "rules_go@0.46.0",
+        "io_bazel_rules_go": "rules_go@0.47.1",
         "com_google_googletest": "googletest@1.14.0.bcr.1",
         "rules_cc": "rules_cc@0.0.9",
         "rules_python": "rules_python@0.31.0",
@@ -4117,6 +4055,102 @@
         ]
       }
     },
+    "@@aspect_rules_js~//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "1abWkulJkafTmfNTPiAC/wL3tJzAnKuwkTuu/cZ5oBY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pnpm__links": {
+            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
+            "ruleClassName": "npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "bins": {},
+              "npm_translate_lock_repo": "",
+              "package_visibility": [
+                "//visibility:public"
+              ]
+            }
+          },
+          "pnpm": {
+            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
+            "ruleClassName": "npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "generate_bzl_library_targets": false
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_bazel_lib~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "aspect_rules_js~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "oxBYiu/0vMVSRQBLFc5WmtGTIfulsS5vGbZijRpCEfA=",
@@ -4182,6 +4216,33 @@
             "bazel_tools"
           ]
         ]
+      }
+    },
+    "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "S0n86BFe4SJ3lRaZiRA5D46oH52UO2hP1T50t/zldOw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "android_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
+              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
+            }
+          },
+          "android_gmaven_r8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "57a696749695a09381a87bc2f08c3a8ed06a717a5caa3ef878a3077e0d3af19d",
+              "url": "https://maven.google.com/com/android/tools/r8/8.1.56/r8-8.1.56.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
@@ -4261,6 +4322,31 @@
               "urls": [
                 "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
               ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@buildozer~//:buildozer_binary.bzl%buildozer_binary": {
+      "general": {
+        "bzlTransitiveDigest": "EleDU/FQ1+e/RgkW3aIDmdaxZEthvoWQhsqFTxiSgMI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildozer_binary": {
+            "bzlFile": "@@buildozer~//private:buildozer_binary.bzl",
+            "ruleClassName": "_buildozer_binary_repo",
+            "attributes": {
+              "sha256": {
+                "darwin-amd64": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e",
+                "darwin-arm64": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d",
+                "linux-amd64": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119",
+                "linux-arm64": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa",
+                "windows-amd64": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
+              },
+              "version": "6.4.0"
             }
           }
         },
@@ -4434,6 +4520,643 @@
         "recordedRepoMappingEntries": []
       }
     },
+    "@@grpc-java~//:repositories.bzl%grpc_java_repositories_extension": {
+      "general": {
+        "bzlTransitiveDigest": "ztHwsjy8jovQmCK9PAM9+Ifgi/h3Sbq69aXYsyy5SNs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "envoy_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b426904abf51ba21dd8947a05694bb3c861d6f5e436e4673e74d7d7bfb6d3188",
+              "strip_prefix": "data-plane-api-268824e4eee3d7770a347a5dc5aaddc0b1b14e24",
+              "urls": [
+                "https://github.com/envoyproxy/data-plane-api/archive/268824e4eee3d7770a347a5dc5aaddc0b1b14e24.tar.gz"
+              ]
+            }
+          },
+          "com_github_cncf_xds": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "xds-e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7",
+              "sha256": "0d33b83f8c6368954e72e7785539f0d272a8aba2f6e2e336ed15fd1514bc9899",
+              "urls": [
+                "https://github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz"
+              ]
+            }
+          },
+          "io_grpc_grpc_proto": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "464e97a24d7d784d9c94c25fa537ba24127af5aae3edd381007b5b98705a0518",
+              "strip_prefix": "grpc-proto-08911e9d585cbda3a55eb1dcc4b99c89aebccff8",
+              "urls": [
+                "https://github.com/grpc/grpc-proto/archive/08911e9d585cbda3a55eb1dcc4b99c89aebccff8.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc-java~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@grpc~//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "b66XrJUCXOv86rjQOuvgxHj61vwp9oqGhFLq5v/ucwQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "io_opencensus_cpp": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "46b3b5812c150a21bacf860c2f76fc42b89773ed77ee954c32adeb8593aa2a8e",
+              "strip_prefix": "opencensus-cpp-5501a1a255805e0be83a41348bb5f2630d5ed6b3",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/5501a1a255805e0be83a41348bb5f2630d5ed6b3.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-cpp/archive/5501a1a255805e0be83a41348bb5f2630d5ed6b3.tar.gz"
+              ]
+            }
+          },
+          "com_github_libuv_libuv": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@grpc~//third_party:libuv.BUILD",
+              "sha256": "5ca4e9091f3231d8ad8801862dc4e851c23af89c69141d27723157776f7291e7",
+              "strip_prefix": "libuv-02a9e1be252b623ee032a3137c0b0c94afbe6809",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/libuv/libuv/archive/02a9e1be252b623ee032a3137c0b0c94afbe6809.tar.gz",
+                "https://github.com/libuv/libuv/archive/02a9e1be252b623ee032a3137c0b0c94afbe6809.tar.gz"
+              ]
+            }
+          },
+          "com_google_googleapis": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5bb6b0253ccf64b53d6c7249625a7e3f6c3bc6402abd52d3778bfa48258703a0",
+              "strip_prefix": "googleapis-2f9af297c84c55c8b871ba4495e01ade42476c92",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.tar.gz"
+              ]
+            }
+          },
+          "upb": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7d19f2ac9c1e508a86a272913d9aa67c8147827f949035828910bb05d9f2cf03",
+              "strip_prefix": "upb-61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz",
+                "https://github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz"
+              ]
+            }
+          },
+          "rules_cc": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3d9e271e2876ba42e114c9b9bc51454e379cbf0ec9ef9d40e2ae4cec61a31b40",
+              "strip_prefix": "rules_cc-0.0.6",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz",
+                "https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"
+              ]
+            }
+          },
+          "boringssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f150aa2d73017fe8576a8a335f29030488d851c94368a79ac56142d107bf9e9a",
+              "strip_prefix": "boringssl-e46383fc18d08def901b2ed5a194295693e905c7",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/e46383fc18d08def901b2ed5a194295693e905c7.tar.gz",
+                "https://github.com/google/boringssl/archive/e46383fc18d08def901b2ed5a194295693e905c7.tar.gz"
+              ]
+            }
+          },
+          "bazel_gazelle": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz"
+              ]
+            }
+          },
+          "opencensus_proto": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
+              "strip_prefix": "opencensus-proto-0.3.0/src",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
+              ],
+              "patches": [
+                "@@grpc~//third_party:opencensus-proto.patch"
+              ],
+              "patch_args": [
+                "-p2"
+              ]
+            }
+          },
+          "com_googlesource_code_re2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
+              "strip_prefix": "re2-2022-04-01",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/re2/archive/2022-04-01.tar.gz",
+                "https://github.com/google/re2/archive/2022-04-01.tar.gz"
+              ]
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz"
+              ],
+              "sha256": "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44"
+            }
+          },
+          "com_github_cares_cares": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@grpc~//third_party:cares/cares.BUILD",
+              "sha256": "bf26e5b25e259911914a85ae847b6d723488adb5af4f8bdeb9d0871a318476e3",
+              "strip_prefix": "c-ares-6360e96b5cf8e5980c887ce58ef727e53d77243a",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/c-ares/c-ares/archive/6360e96b5cf8e5980c887ce58ef727e53d77243a.tar.gz",
+                "https://github.com/c-ares/c-ares/archive/6360e96b5cf8e5980c887ce58ef727e53d77243a.tar.gz"
+              ]
+            }
+          },
+          "build_bazel_apple_support": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
+                "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz"
+              ]
+            }
+          },
+          "zlib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@grpc~//third_party:zlib.BUILD",
+              "sha256": "90f43a9c998740e8a0db24b0af0147033db2aaaa99423129abbd76640757cac9",
+              "strip_prefix": "zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/madler/zlib/archive/04f42ceca40f73e2978b50e93806c2a18c1281fc.tar.gz",
+                "https://github.com/madler/zlib/archive/04f42ceca40f73e2978b50e93806c2a18c1281fc.tar.gz"
+              ]
+            }
+          },
+          "com_google_googletest": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c8de6c60e12ad014a28225c5247ee735861d85cf906df617f6a29954ca05f547",
+              "strip_prefix": "googletest-0e402173c97aea7a00749e825b194bfede4f2e45",
+              "urls": [
+                "https://github.com/google/googletest/archive/0e402173c97aea7a00749e825b194bfede4f2e45.tar.gz"
+              ]
+            }
+          },
+          "envoy_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3c7372b5cb33e5e5cc3afd82573fc6275f9a2cac8b1530e1af14f52f34047328",
+              "strip_prefix": "data-plane-api-68d4315167352ffac71f149a43b8088397d3f33d",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/68d4315167352ffac71f149a43b8088397d3f33d.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/68d4315167352ffac71f149a43b8088397d3f33d.tar.gz"
+              ]
+            }
+          },
+          "com_google_fuzztest": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cdf8d8cd3cdc77280a7c59b310edf234e489a96b6e727cb271e7dfbeb9bcca8d",
+              "strip_prefix": "fuzztest-4ecaeb5084a061a862af8f86789ee184cd3d3f18",
+              "urls": [
+                "https://github.com/google/fuzztest/archive/4ecaeb5084a061a862af8f86789ee184cd3d3f18.tar.gz"
+              ]
+            }
+          },
+          "build_bazel_rules_apple": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz",
+                "https://github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz"
+              ]
+            }
+          },
+          "com_github_cncf_udpa": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0d33b83f8c6368954e72e7785539f0d272a8aba2f6e2e336ed15fd1514bc9899",
+              "strip_prefix": "xds-e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz",
+                "https://github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz"
+              ]
+            }
+          },
+          "com_github_google_benchmark": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a43368d3ec48afe784573cf962fe98c084e89a1e3d176c00715a84366316e7d",
+              "strip_prefix": "benchmark-361e8d1cfe0c6c36d30b39f1b61302ece5507320",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz",
+                "https://github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz"
+              ]
+            }
+          },
+          "com_envoyproxy_protoc_gen_validate": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "protoc-gen-validate-4694024279bdac52b77e22dc87808bd0fd732b69",
+              "sha256": "1e490b98005664d149b379a9529a6aa05932b8a11b76b4cd86f3d22d76346f47",
+              "urls": [
+                "https://github.com/envoyproxy/protoc-gen-validate/archive/4694024279bdac52b77e22dc87808bd0fd732b69.tar.gz"
+              ],
+              "patches": [
+                "@@grpc~//third_party:protoc-gen-validate.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36",
+              "strip_prefix": "abseil-cpp-20230125.3",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz",
+                "https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz"
+              ]
+            }
+          },
+          "bazel_toolchains": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
+              "strip_prefix": "bazel-toolchains-4.1.0",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "bazel_compdb": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bcecfd622c4ef272fd4ba42726a52e140b961c4eac23025f18b346c968a8cfb4",
+              "strip_prefix": "bazel-compilation-database-0.4.5",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz",
+                "https://github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc~",
+            "com_github_grpc_grpc",
+            "grpc~"
+          ]
+        ]
+      }
+    },
+    "@@grpc~//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "A90Lp1WXcRiOVTDXecqjAWNWGO/vvn13/YSCLLST2Xo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "bzlFile": "@@grpc~~grpc_repo_deps_ext~com_google_googleapis//:repository_rules.bzl",
+            "ruleClassName": "switched_rules",
+            "attributes": {
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "@com_github_grpc_grpc//bazel:python_rules.bzl",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "@com_github_grpc_grpc//bazel:python_rules.bzl",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "native.cc_proto_library",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc~",
+            "com_envoyproxy_protoc_gen_validate",
+            "grpc~~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate"
+          ],
+          [
+            "grpc~",
+            "com_google_googleapis",
+            "grpc~~grpc_repo_deps_ext~com_google_googleapis"
+          ],
+          [
+            "grpc~",
+            "com_google_protobuf",
+            "protobuf~"
+          ],
+          [
+            "grpc~",
+            "envoy_api",
+            "grpc~~grpc_repo_deps_ext~envoy_api"
+          ],
+          [
+            "grpc~",
+            "io_bazel_rules_go",
+            "rules_go~"
+          ],
+          [
+            "grpc~",
+            "upb",
+            "upb~"
+          ],
+          [
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle",
+            "bazel_gazelle",
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle"
+          ],
+          [
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc~~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
+            "bazel_gazelle",
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle"
+          ],
+          [
+            "grpc~~grpc_repo_deps_ext~envoy_api",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc~~grpc_repo_deps_ext~envoy_api",
+            "envoy_api",
+            "grpc~~grpc_repo_deps_ext~envoy_api"
+          ],
+          [
+            "protobuf~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go~",
+            "io_bazel_rules_go",
+            "rules_go~"
+          ],
+          [
+            "upb~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@grpc~//bazel:grpc_python_deps.bzl%grpc_python_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "E+v312MUu21ixWMBwHvdN3sIoN6CnWWAu+2NbB6dmTk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cython": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@grpc~//third_party:cython.BUILD",
+              "sha256": "a2da56cc22be823acf49741b9aa3aa116d4f07fa8e8b35a3cb08b8447b37c607",
+              "strip_prefix": "cython-0.29.35",
+              "urls": [
+                "https://github.com/cython/cython/archive/0.29.35.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc~",
+            "com_github_grpc_grpc",
+            "grpc~"
+          ]
+        ]
+      }
+    },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "bzlFile": "@@platforms//host:extension.bzl",
+            "ruleClassName": "host_platform_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@protobuf~//:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "aGnO/HqVtCmRLEQWGCuKp7jwX+lCh/nc3/hI3clfwD8=",
@@ -4456,6 +5179,41 @@
         "recordedRepoMappingEntries": [
           [
             "protobuf~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel~//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "DJPCeiYqQS2i13szWN5NSI6sC6eaWgvECEyY/oNXWms=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel~//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "bzlFile": "@@pybind11_bazel~//:python_configure.bzl",
+            "ruleClassName": "python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel~//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel~",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -4526,6 +5284,1881 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_dotnet~//dotnet:paket.paket2bazel_dependencies_extension.bzl%paket2bazel_dependencies_extension": {
+      "general": {
+        "bzlTransitiveDigest": "vERjV941lMOKpr/lMca55KOrp3cFiiCKC6MX4MCOcvs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.system.io.filesystem.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem",
+              "version": "4.3.0",
+              "sha512": "sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g=="
+            }
+          },
+          "nuget.system.diagnostics.debug.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.debug",
+              "version": "4.3.0",
+              "sha512": "sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA=="
+            }
+          },
+          "nuget.runtime.native.system.net.http.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.net.http",
+              "version": "4.3.1",
+              "sha512": "sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q=="
+            }
+          },
+          "nuget.nuget.librarymodel.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "6.9.1",
+              "sha512": "sha512-wjmw2ZOmRFzLBzKyA6Tx62SVKfopE3Toz+oo0+H38zp7yK6GFcTiHZqjerN1AyYgz85Rl5bo752a0dv6Cpkc3A=="
+            }
+          },
+          "nuget.microsoft.extensions.fileproviders.abstractions.v8.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.fileproviders.abstractions",
+              "version": "8.0.0",
+              "sha512": "sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ=="
+            }
+          },
+          "nuget.system.security.cryptography.encoding.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A=="
+            }
+          },
+          "nuget.system.threading.tasks.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading.tasks",
+              "version": "4.3.0",
+              "sha512": "sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw=="
+            }
+          },
+          "nuget.system.diagnostics.diagnosticsource.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.diagnosticsource",
+              "version": "6.0.0",
+              "sha512": "sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg=="
+            }
+          },
+          "nuget.nuget.credentials.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "6.9.1",
+              "sha512": "sha512-VQWJ+wbjViRbVfVa21J1YFMI9fYV/xoQyk2xn7T4pXbindaopfWuPXni3Mb3N1yD12xIUvFf6AB1r/Hb2TI9pw=="
+            }
+          },
+          "nuget.system.collections.concurrent.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections.concurrent",
+              "version": "4.3.0",
+              "sha512": "sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg=="
+            }
+          },
+          "nuget.system.security.cryptography.x509certificates.v4.3.2": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.x509certificates",
+              "version": "4.3.2",
+              "sha512": "sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA=="
+            }
+          },
+          "nuget.system.globalization.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization",
+              "version": "4.3.0",
+              "sha512": "sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g=="
+            }
+          },
+          "nuget.system.globalization.extensions.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.extensions",
+              "version": "4.3.0",
+              "sha512": "sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q=="
+            }
+          },
+          "nuget.system.threading.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading",
+              "version": "4.3.0",
+              "sha512": "sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA=="
+            }
+          },
+          "nuget.microsoft.extensions.primitives.v8.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.primitives",
+              "version": "8.0.0",
+              "sha512": "sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ=="
+            }
+          },
+          "nuget.microsoft.csharp.v4.7.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.csharp",
+              "version": "4.7.0",
+              "sha512": "sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.microsoft.netcore.targets.v5.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.targets",
+              "version": "5.0.0",
+              "sha512": "sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw=="
+            }
+          },
+          "nuget.nuget.packaging.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "6.9.1",
+              "sha512": "sha512-5GflbMRqaWyIUVODkbw3WFS0a5RMC/IznBHVutAxJtTMi8yIe9QKIqS2OHru+syL5dlCShxSQoKMdcz80CMUlQ=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "nuget.system.text.json.v5.0.2": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.json",
+              "version": "5.0.2",
+              "sha512": "sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ=="
+            }
+          },
+          "nuget.runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ=="
+            }
+          },
+          "nuget.system.drawing.common.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.drawing.common",
+              "version": "6.0.0",
+              "sha512": "sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A=="
+            }
+          },
+          "nuget.system.net.primitives.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.primitives",
+              "version": "4.3.1",
+              "sha512": "sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q=="
+            }
+          },
+          "nuget.runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ=="
+            }
+          },
+          "nuget.runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA=="
+            }
+          },
+          "nuget.system.linq.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.linq",
+              "version": "4.3.0",
+              "sha512": "sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA=="
+            }
+          },
+          "nuget.microsoft.win32.systemevents.v6.0.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.win32.systemevents",
+              "version": "6.0.1",
+              "sha512": "sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A=="
+            }
+          },
+          "nuget.system.net.http.v4.3.4": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http",
+              "version": "4.3.4",
+              "sha512": "sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q=="
+            }
+          },
+          "paket.paket2bazel_dependencies": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_repo.bzl",
+            "ruleClassName": "_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.paket2bazel_dependencies",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net462\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net47\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net471\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net472\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net48\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net5.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net6.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net7.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net8.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"]},\"framework_list\":[],\"id\":\"Argu\",\"name\":\"Argu\",\"sha512\":\"sha512-ihcJ2ZDYMfyAfCXxQUXJe/N+R3W3Ag5qqnRo07TynHKhxDatwdu9QUKjV4Ej8kTSbkORkpfDJ5zr6O3ZisP5TA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.2.3\"}",
+                "{\"dependencies\":{\"net11\":[\"FSharp.Core\"],\"net20\":[\"FSharp.Core\"],\"net30\":[\"FSharp.Core\"],\"net35\":[\"FSharp.Core\"],\"net40\":[\"FSharp.Core\"],\"net403\":[\"FSharp.Core\"],\"net45\":[\"FSharp.Core\"],\"net451\":[\"FSharp.Core\"],\"net452\":[\"FSharp.Core\"],\"net46\":[\"FSharp.Core\"],\"net461\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net462\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net47\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net471\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net472\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net48\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net5.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net6.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net7.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net8.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.2\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard\":[\"FSharp.Core\"],\"netstandard1.0\":[\"FSharp.Core\"],\"netstandard1.1\":[\"FSharp.Core\"],\"netstandard1.2\":[\"FSharp.Core\"],\"netstandard1.3\":[\"FSharp.Core\"],\"netstandard1.4\":[\"FSharp.Core\"],\"netstandard1.5\":[\"FSharp.Core\"],\"netstandard1.6\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.1\":[\"NETStandard.Library\",\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"Chessie\",\"name\":\"Chessie\",\"sha512\":\"sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.6.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"FSharp.Core\",\"name\":\"FSharp.Core\",\"sha512\":\"sha512-XsUCYJqGfuL+jSVEiep/zq7R4zCM4MJSwAgaeN/q8zV2iYrXsE23hQrsDJaCiSSTnbPg7YD2ZGEzUcmE6LnM6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.200\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.CSharp\",\"name\":\"Microsoft.CSharp\",\"sha512\":\"sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Microsoft.Extensions.Primitives\"],\"net462\":[\"Microsoft.Extensions.Primitives\"],\"net47\":[\"Microsoft.Extensions.Primitives\"],\"net471\":[\"Microsoft.Extensions.Primitives\"],\"net472\":[\"Microsoft.Extensions.Primitives\"],\"net48\":[\"Microsoft.Extensions.Primitives\"],\"net5.0\":[\"Microsoft.Extensions.Primitives\"],\"net6.0\":[\"Microsoft.Extensions.Primitives\"],\"net7.0\":[\"Microsoft.Extensions.Primitives\"],\"net8.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.1\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.2\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.1\":[\"Microsoft.Extensions.Primitives\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Microsoft.Extensions.Primitives\"],\"netstandard2.1\":[\"Microsoft.Extensions.Primitives\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileProviders.Abstractions\",\"name\":\"Microsoft.Extensions.FileProviders.Abstractions\",\"sha512\":\"sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileSystemGlobbing\",\"name\":\"Microsoft.Extensions.FileSystemGlobbing\",\"sha512\":\"sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.Primitives\",\"name\":\"Microsoft.Extensions.Primitives\",\"sha512\":\"sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"name\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Targets\",\"name\":\"Microsoft.NETCore.Targets\",\"sha512\":\"sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"name\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Win32.SystemEvents\",\"name\":\"Microsoft.Win32.SystemEvents\",\"sha512\":\"sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Mono.Cecil\",\"name\":\"Mono.Cecil\",\"sha512\":\"sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.11.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization.Calendars\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Net.Http\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"name\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.2\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.3\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.4\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.5\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.6\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"name\":\"Newtonsoft.Json\",\"sha512\":\"sha512-mbJSvHfRxfX3tR/U6n1WU+mWHXswYc+SB/hkOpx8yZZe68hNZGfymJu0cjsaJEkVzCMqePiU6LdIyogqfIn7kg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"name\":\"NuGet.Commands\",\"sha512\":\"sha512-HOkPRzY+cnsVjUFbXhW39MfUKAOIoX3uQsfQsMuf+2wKkbfx9A8cjLhjNNi242jTHYhuWDUbIEqUERQG2NoxNw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"name\":\"NuGet.Common\",\"sha512\":\"sha512-DXYOLj6bfp5XkO7mXlmvZ4/VGUfm5T4lUoQEpY/8LWy2b60s47zslhR22eDhZg5LpO35rECtIAKVCI2iRQ+qKQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"name\":\"NuGet.Configuration\",\"sha512\":\"sha512-AdyOMLmAtAmIiVJAh0Y1ewrqerDE//K3MRqD2+Kywe+hTnpS/XvrvwzOstf1IXiHp13rG6vFwDYVc1MIqEF0fw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"name\":\"NuGet.Credentials\",\"sha512\":\"sha512-VQWJ+wbjViRbVfVa21J1YFMI9fYV/xoQyk2xn7T4pXbindaopfWuPXni3Mb3N1yD12xIUvFf6AB1r/Hb2TI9pw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"name\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-d4WJ/pba9Kkj2DB+p/IH3EgRFt0ZD0mM5ftDDda2IA29NXu+MEew+YRuM/2MUb/X13lMfZkwqeeyBLlX+9RCqA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"name\":\"NuGet.Frameworks\",\"sha512\":\"sha512-n9zfKo3Hwpmih3cHvyKv3rF7vle4/NCa23jLuGajLJEn2iCXvcjq3UhSNj2ZTIUMq2OSS7RjioDQCEjqMDs2aQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"name\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-wjmw2ZOmRFzLBzKyA6Tx62SVKfopE3Toz+oo0+H38zp7yK6GFcTiHZqjerN1AyYgz85Rl5bo752a0dv6Cpkc3A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"name\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-TP7oMZoHAC8Js19gT5pT+HA0EICDQwRfkhMfZcJyYOH4WM7+46mB5tbqJrFZCrPqEyWUGL1Xaqngss/6QVKjbw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"name\":\"Nuget.Packaging\",\"sha512\":\"sha512-5GflbMRqaWyIUVODkbw3WFS0a5RMC/IznBHVutAxJtTMi8yIe9QKIqS2OHru+syL5dlCShxSQoKMdcz80CMUlQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"name\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-NT4T/3PVm7z8GwDHHjQpK96EH3FUDO7dviFBSgJzGvXzLkmIhLoEwYeO6/K4T+TIEcsGzZ6+cVwwGunjfXts+Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Text.Json\"],\"net462\":[\"System.Text.Json\"],\"net47\":[\"System.Text.Json\"],\"net471\":[\"System.Text.Json\"],\"net472\":[\"System.Text.Json\"],\"net48\":[\"System.Text.Json\"],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Text.Json\"],\"netcoreapp2.1\":[\"System.Text.Json\"],\"netcoreapp2.2\":[\"System.Text.Json\"],\"netcoreapp3.0\":[\"System.Text.Json\"],\"netcoreapp3.1\":[\"System.Text.Json\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Text.Json\"],\"netstandard2.1\":[\"System.Text.Json\"]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"name\":\"NuGet.Protocol\",\"sha512\":\"sha512-XLoO4nWfUCOmvb3f1PyIKq+fOUTw8RI3zmMqdkTubjMdIBzfvreGiZ74nqxgs42q0Lyj3Dh6+5/LK7v/XAZLLA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"name\":\"NuGet.Resolver\",\"sha512\":\"sha512-ITKdXrRHjWV9vVVt2ZPBPTfZBqSGSGvUIAPfyxCqUmSqPpbs3VlnMJ9OcvmNJTVZHIjtI2EMlcd9/UA3iBljiw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"name\":\"NuGet.Versioning\",\"sha512\":\"sha512-wmE9WvXY9N9tWH3zPTOU3Ct+IpJST7Qtf6ZXaw6DEgLS8gYJ/Q773R/tFT/jGIHb6kJQWoi5vStIqioIoZLtUg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.9.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net48\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net5.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"Paket.Core\",\"name\":\"Paket.Core\",\"sha512\":\"sha512-aN4vT3PJ+MFlXupkjqVXuQNLYTIPj6e0CYor+uEgy4fQcw8aVGvGrPQEARNVQIh+mHY3LWEIizY5ABPTcr537g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System\",\"name\":\"runtime.native.System\",\"sha512\":\"sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Net.Http\",\"name\":\"runtime.native.System.Net.Http\",\"sha512\":\"sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net20\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net30\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net35\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net40\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net403\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net45\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net451\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net452\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net46\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net461\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net462\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net47\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net471\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net472\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net48\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net5.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net6.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net7.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net8.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.3\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.4\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.5\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.6\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.Apple\",\"name\":\"runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net20\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net30\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net35\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net40\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net403\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net45\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net451\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net452\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net46\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net461\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net462\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net47\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net471\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net472\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net48\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net5.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net6.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net7.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net8.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.3\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.4\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.5\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.6\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\",\"name\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"name\":\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Collections\",\"name\":\"System.Collections\",\"sha512\":\"sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Collections.Concurrent\",\"name\":\"System.Collections.Concurrent\",\"sha512\":\"sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"name\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Permissions\"],\"net462\":[\"System.Security.Permissions\"],\"net47\":[\"System.Security.Permissions\"],\"net471\":[\"System.Security.Permissions\"],\"net472\":[\"System.Security.Permissions\"],\"net48\":[\"System.Security.Permissions\"],\"net5.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net6.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net7.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net8.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.2\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"]},\"framework_list\":[],\"id\":\"System.Configuration.ConfigurationManager\",\"name\":\"System.Configuration.ConfigurationManager\",\"sha512\":\"sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Debug\",\"name\":\"System.Diagnostics.Debug\",\"sha512\":\"sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net8.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.DiagnosticSource\",\"name\":\"System.Diagnostics.DiagnosticSource\",\"sha512\":\"sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Tracing\",\"name\":\"System.Diagnostics.Tracing\",\"sha512\":\"sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.Win32.SystemEvents\"],\"net6.0\":[\"Microsoft.Win32.SystemEvents\"],\"net7.0\":[\"Microsoft.Win32.SystemEvents\"],\"net8.0\":[\"Microsoft.Win32.SystemEvents\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"Microsoft.Win32.SystemEvents\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Drawing.Common\",\"name\":\"System.Drawing.Common\",\"sha512\":\"sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"name\":\"System.Formats.Asn1\",\"sha512\":\"sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization\",\"name\":\"System.Globalization\",\"sha512\":\"sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization.Calendars\",\"name\":\"System.Globalization.Calendars\",\"sha512\":\"sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"]},\"framework_list\":[],\"id\":\"System.Globalization.Extensions\",\"name\":\"System.Globalization.Extensions\",\"sha512\":\"sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO\",\"name\":\"System.IO\",\"sha512\":\"sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.IO.FileSystem.Primitives\"],\"net461\":[\"System.IO.FileSystem.Primitives\"],\"net462\":[\"System.IO.FileSystem.Primitives\"],\"net47\":[\"System.IO.FileSystem.Primitives\"],\"net471\":[\"System.IO.FileSystem.Primitives\"],\"net472\":[\"System.IO.FileSystem.Primitives\"],\"net48\":[\"System.IO.FileSystem.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem\",\"name\":\"System.IO.FileSystem\",\"sha512\":\"sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\"],\"net6.0\":[\"System.Runtime\"],\"net7.0\":[\"System.Runtime\"],\"net8.0\":[\"System.Runtime\"],\"netcoreapp1.0\":[\"System.Runtime\"],\"netcoreapp1.1\":[\"System.Runtime\"],\"netcoreapp2.0\":[\"System.Runtime\"],\"netcoreapp2.1\":[\"System.Runtime\"],\"netcoreapp2.2\":[\"System.Runtime\"],\"netcoreapp3.0\":[\"System.Runtime\"],\"netcoreapp3.1\":[\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\"],\"netstandard1.4\":[\"System.Runtime\"],\"netstandard1.5\":[\"System.Runtime\"],\"netstandard1.6\":[\"System.Runtime\"],\"netstandard2.0\":[\"System.Runtime\"],\"netstandard2.1\":[\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem.Primitives\",\"name\":\"System.IO.FileSystem.Primitives\",\"sha512\":\"sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.1\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.2\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.3\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.4\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.5\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Linq\",\"name\":\"System.Linq\",\"sha512\":\"sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"System.Security.Cryptography.X509Certificates\"],\"net462\":[\"System.Security.Cryptography.X509Certificates\"],\"net47\":[\"System.Security.Cryptography.X509Certificates\"],\"net471\":[\"System.Security.Cryptography.X509Certificates\"],\"net472\":[\"System.Security.Cryptography.X509Certificates\"],\"net48\":[\"System.Security.Cryptography.X509Certificates\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Net.Http\",\"name\":\"System.Net.Http\",\"sha512\":\"sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Net.Http.WinHttpHandler\",\"name\":\"System.Net.Http.WinHttpHandler\",\"sha512\":\"sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Net.Primitives\",\"name\":\"System.Net.Primitives\",\"sha512\":\"sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection\",\"name\":\"System.Reflection\",\"sha512\":\"sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection.Primitives\",\"name\":\"System.Reflection.Primitives\",\"sha512\":\"sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Resources.ResourceManager\",\"name\":\"System.Resources.ResourceManager\",\"sha512\":\"sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"System.Runtime\",\"name\":\"System.Runtime\",\"sha512\":\"sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Runtime.CompilerServices.Unsafe\",\"name\":\"System.Runtime.CompilerServices.Unsafe\",\"sha512\":\"sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Extensions\",\"name\":\"System.Runtime.Extensions\",\"sha512\":\"sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Handles\",\"name\":\"System.Runtime.Handles\",\"sha512\":\"sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[\"System.Runtime\"],\"net47\":[\"System.Runtime\"],\"net471\":[\"System.Runtime\"],\"net472\":[\"System.Runtime\"],\"net48\":[\"System.Runtime\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Runtime.InteropServices\",\"name\":\"System.Runtime.InteropServices\",\"sha512\":\"sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\"],\"netstandard1.2\":[\"System.Runtime\"],\"netstandard1.3\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.4\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.5\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.6\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Runtime.Numerics\",\"name\":\"System.Runtime.Numerics\",\"sha512\":\"sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.AccessControl\",\"name\":\"System.Security.AccessControl\",\"sha512\":\"sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.5\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Algorithms\",\"name\":\"System.Security.Cryptography.Algorithms\",\"sha512\":\"sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"name\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Csp\",\"name\":\"System.Security.Cryptography.Csp\",\"sha512\":\"sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Encoding\",\"name\":\"System.Security.Cryptography.Encoding\",\"sha512\":\"sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.OpenSsl\",\"name\":\"System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"name\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Primitives\",\"name\":\"System.Security.Cryptography.Primitives\",\"sha512\":\"sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"name\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.X509Certificates\",\"name\":\"System.Security.Cryptography.X509Certificates\",\"sha512\":\"sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.AccessControl\"],\"net462\":[\"System.Security.AccessControl\"],\"net47\":[\"System.Security.AccessControl\"],\"net471\":[\"System.Security.AccessControl\"],\"net472\":[\"System.Security.AccessControl\"],\"net48\":[\"System.Security.AccessControl\"],\"net5.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net6.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net7.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net8.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.AccessControl\"],\"netcoreapp2.1\":[\"System.Security.AccessControl\"],\"netcoreapp2.2\":[\"System.Security.AccessControl\"],\"netcoreapp3.0\":[\"System.Security.AccessControl\"],\"netcoreapp3.1\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.AccessControl\"],\"netstandard2.1\":[\"System.Security.AccessControl\"]},\"framework_list\":[],\"id\":\"System.Security.Permissions\",\"name\":\"System.Security.Permissions\",\"sha512\":\"sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Text.Encoding\",\"name\":\"System.Text.Encoding\",\"sha512\":\"sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Text.Json\",\"name\":\"System.Text.Json\",\"sha512\":\"sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Threading\",\"name\":\"System.Threading\",\"sha512\":\"sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Threading.Tasks\",\"name\":\"System.Threading.Tasks\",\"sha512\":\"sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Drawing.Common\"],\"net6.0\":[\"System.Drawing.Common\"],\"net7.0\":[\"System.Drawing.Common\"],\"net8.0\":[\"System.Drawing.Common\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"System.Drawing.Common\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Windows.Extensions\",\"name\":\"System.Windows.Extensions\",\"sha512\":\"sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.core": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              },
+              "framework_list": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.core": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              }
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "6.9.1",
+              "sha512": "sha512-d4WJ/pba9Kkj2DB+p/IH3EgRFt0ZD0mM5ftDDda2IA29NXu+MEew+YRuM/2MUb/X13lMfZkwqeeyBLlX+9RCqA=="
+            }
+          },
+          "nuget.nuget.commands.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "6.9.1",
+              "sha512": "sha512-HOkPRzY+cnsVjUFbXhW39MfUKAOIoX3uQsfQsMuf+2wKkbfx9A8cjLhjNNi242jTHYhuWDUbIEqUERQG2NoxNw=="
+            }
+          },
+          "nuget.nuget.versioning.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "6.9.1",
+              "sha512": "sha512-wmE9WvXY9N9tWH3zPTOU3Ct+IpJST7Qtf6ZXaw6DEgLS8gYJ/Q773R/tFT/jGIHb6kJQWoi5vStIqioIoZLtUg=="
+            }
+          },
+          "nuget.system.net.http.winhttphandler.v6.0.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http.winhttphandler",
+              "version": "6.0.1",
+              "sha512": "sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ=="
+            }
+          },
+          "nuget.system.globalization.calendars.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.calendars",
+              "version": "4.3.0",
+              "sha512": "sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg=="
+            }
+          },
+          "nuget.system.text.encoding.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw=="
+            }
+          },
+          "nuget.system.runtime.compilerservices.unsafe.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.compilerservices.unsafe",
+              "version": "6.0.0",
+              "sha512": "sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw=="
+            }
+          },
+          "nuget.microsoft.extensions.filesystemglobbing.v8.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.filesystemglobbing",
+              "version": "8.0.0",
+              "sha512": "sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q=="
+            }
+          },
+          "nuget.runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw=="
+            }
+          },
+          "nuget.runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ=="
+            }
+          },
+          "nuget.system.runtime.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime",
+              "version": "4.3.1",
+              "sha512": "sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA=="
+            }
+          },
+          "nuget.runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow=="
+            }
+          },
+          "nuget.paket.core.v8.0.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "paket.core",
+              "version": "8.0.3",
+              "sha512": "sha512-aN4vT3PJ+MFlXupkjqVXuQNLYTIPj6e0CYor+uEgy4fQcw8aVGvGrPQEARNVQIh+mHY3LWEIizY5ABPTcr537g=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "6.9.1",
+              "sha512": "sha512-TP7oMZoHAC8Js19gT5pT+HA0EICDQwRfkhMfZcJyYOH4WM7+46mB5tbqJrFZCrPqEyWUGL1Xaqngss/6QVKjbw=="
+            }
+          },
+          "nuget.mono.cecil.v0.11.4": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mono.cecil",
+              "version": "0.11.4",
+              "sha512": "sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA=="
+            }
+          },
+          "nuget.nuget.configuration.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "6.9.1",
+              "sha512": "sha512-AdyOMLmAtAmIiVJAh0Y1ewrqerDE//K3MRqD2+Kywe+hTnpS/XvrvwzOstf1IXiHp13rG6vFwDYVc1MIqEF0fw=="
+            }
+          },
+          "nuget.system.reflection.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection",
+              "version": "4.3.0",
+              "sha512": "sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw=="
+            }
+          },
+          "nuget.system.security.cryptography.algorithms.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.algorithms",
+              "version": "4.3.1",
+              "sha512": "sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.system.security.cryptography.openssl.v5.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.openssl",
+              "version": "5.0.0",
+              "sha512": "sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.3",
+              "sha512": "sha512-mbJSvHfRxfX3tR/U6n1WU+mWHXswYc+SB/hkOpx8yZZe68hNZGfymJu0cjsaJEkVzCMqePiU6LdIyogqfIn7kg=="
+            }
+          },
+          "nuget.system.security.permissions.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.permissions",
+              "version": "6.0.0",
+              "sha512": "sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA=="
+            }
+          },
+          "nuget.nuget.resolver.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "6.9.1",
+              "sha512": "sha512-ITKdXrRHjWV9vVVt2ZPBPTfZBqSGSGvUIAPfyxCqUmSqPpbs3VlnMJ9OcvmNJTVZHIjtI2EMlcd9/UA3iBljiw=="
+            }
+          },
+          "nuget.system.reflection.primitives.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg=="
+            }
+          },
+          "nuget.system.configuration.configurationmanager.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.configuration.configurationmanager",
+              "version": "6.0.0",
+              "sha512": "sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw=="
+            }
+          },
+          "nuget.system.security.cryptography.primitives.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw=="
+            }
+          },
+          "nuget.runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng=="
+            }
+          },
+          "nuget.runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA=="
+            }
+          },
+          "nuget.runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA=="
+            }
+          },
+          "nuget.nuget.common.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "6.9.1",
+              "sha512": "sha512-DXYOLj6bfp5XkO7mXlmvZ4/VGUfm5T4lUoQEpY/8LWy2b60s47zslhR22eDhZg5LpO35rECtIAKVCI2iRQ+qKQ=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ=="
+            }
+          },
+          "nuget.system.collections.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections",
+              "version": "4.3.0",
+              "sha512": "sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v8.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "8.0.0",
+              "sha512": "sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ=="
+            }
+          },
+          "nuget.nuget.protocol.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "6.9.1",
+              "sha512": "sha512-XLoO4nWfUCOmvb3f1PyIKq+fOUTw8RI3zmMqdkTubjMdIBzfvreGiZ74nqxgs42q0Lyj3Dh6+5/LK7v/XAZLLA=="
+            }
+          },
+          "nuget.system.resources.resourcemanager.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.resources.resourcemanager",
+              "version": "4.3.0",
+              "sha512": "sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A=="
+            }
+          },
+          "nuget.chessie.v0.6.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "chessie",
+              "version": "0.6.0",
+              "sha512": "sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg=="
+            }
+          },
+          "nuget.system.security.cryptography.csp.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.csp",
+              "version": "4.3.0",
+              "sha512": "sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ=="
+            }
+          },
+          "nuget.system.runtime.numerics.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.numerics",
+              "version": "4.3.0",
+              "sha512": "sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA=="
+            }
+          },
+          "nuget.runtime.native.system.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system",
+              "version": "4.3.1",
+              "sha512": "sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g=="
+            }
+          },
+          "nuget.nuget.frameworks.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "6.9.1",
+              "sha512": "sha512-n9zfKo3Hwpmih3cHvyKv3rF7vle4/NCa23jLuGajLJEn2iCXvcjq3UhSNj2ZTIUMq2OSS7RjioDQCEjqMDs2aQ=="
+            }
+          },
+          "nuget.system.io.filesystem.primitives.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q=="
+            }
+          },
+          "nuget.argu.v6.2.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "argu",
+              "version": "6.2.3",
+              "sha512": "sha512-ihcJ2ZDYMfyAfCXxQUXJe/N+R3W3Ag5qqnRo07TynHKhxDatwdu9QUKjV4Ej8kTSbkORkpfDJ5zr6O3ZisP5TA=="
+            }
+          },
+          "nuget.runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ=="
+            }
+          },
+          "nuget.runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ=="
+            }
+          },
+          "nuget.system.diagnostics.tracing.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.tracing",
+              "version": "4.3.0",
+              "sha512": "sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g=="
+            }
+          },
+          "nuget.system.runtime.interopservices.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.interopservices",
+              "version": "4.3.0",
+              "sha512": "sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q=="
+            }
+          },
+          "nuget.system.security.accesscontrol.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.accesscontrol",
+              "version": "6.0.0",
+              "sha512": "sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ=="
+            }
+          },
+          "nuget.fsharp.core.v8.0.200": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.core",
+              "version": "8.0.200",
+              "sha512": "sha512-XsUCYJqGfuL+jSVEiep/zq7R4zCM4MJSwAgaeN/q8zV2iYrXsE23hQrsDJaCiSSTnbPg7YD2ZGEzUcmE6LnM6A=="
+            }
+          },
+          "nuget.system.formats.asn1.v8.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "8.0.0",
+              "sha512": "sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.system.io.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io",
+              "version": "4.3.0",
+              "sha512": "sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g=="
+            }
+          },
+          "nuget.system.windows.extensions.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.windows.extensions",
+              "version": "6.0.0",
+              "sha512": "sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA=="
+            }
+          },
+          "nuget.system.runtime.extensions.v4.3.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.extensions",
+              "version": "4.3.1",
+              "sha512": "sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw=="
+            }
+          },
+          "nuget.system.runtime.handles.v4.3.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.handles",
+              "version": "4.3.0",
+              "sha512": "sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ=="
+            }
+          },
+          "nuget.nuget.projectmodel.v6.9.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "6.9.1",
+              "sha512": "sha512-NT4T/3PVm7z8GwDHHjQpK96EH3FUDO7dviFBSgJzGvXzLkmIhLoEwYeO6/K4T+TIEcsGzZ6+cVwwGunjfXts+Q=="
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_dotnet~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet~",
+            "local_config_platform",
+            "local_config_platform"
+          ],
+          [
+            "rules_dotnet~",
+            "rules_dotnet",
+            "rules_dotnet~"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet~//dotnet:paket.rules_dotnet_nuget_packages_extension.bzl%rules_dotnet_nuget_packages_extension": {
+      "general": {
+        "bzlTransitiveDigest": "XKtrcKhRL7gRyXOAZuTVq/mre72u7i0FUzXj1MCGCJE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.nuget.frameworks.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "5.10.0",
+              "sha512": "sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg=="
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "5.10.0",
+              "sha512": "sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v6.0.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "6.0.1",
+              "sha512": "sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg=="
+            }
+          },
+          "nuget.nuget.configuration.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "5.10.0",
+              "sha512": "sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.1": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.1",
+              "sha512": "sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ=="
+            }
+          },
+          "nuget.nunit.v3.12.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunit",
+              "version": "3.12.0",
+              "sha512": "sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ=="
+            }
+          },
+          "nuget.system.formats.asn1.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "6.0.0",
+              "sha512": "sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.nuget.versioning.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "5.10.0",
+              "sha512": "sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg=="
+            }
+          },
+          "nuget.mcmaster.extensions.commandlineutils.v2.5.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mcmaster.extensions.commandlineutils",
+              "version": "2.5.0",
+              "sha512": "sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw=="
+            }
+          },
+          "nuget.nuget.projectmodel.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "5.10.0",
+              "sha512": "sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA=="
+            }
+          },
+          "nuget.system.componentmodel.annotations.v5.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.annotations",
+              "version": "5.0.0",
+              "sha512": "sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA=="
+            }
+          },
+          "nuget.nuget.credentials.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "5.10.0",
+              "sha512": "sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A=="
+            }
+          },
+          "nuget.nunitlite.v3.12.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunitlite",
+              "version": "3.12.0",
+              "sha512": "sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "nuget.nuget.packaging.core.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging.core",
+              "version": "5.10.0",
+              "sha512": "sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "5.10.0",
+              "sha512": "sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA=="
+            }
+          },
+          "nuget.nuget.packaging.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "5.10.0",
+              "sha512": "sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ=="
+            }
+          },
+          "nuget.nuget.protocol.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "5.10.0",
+              "sha512": "sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ=="
+            }
+          },
+          "paket.rules_dotnet_nuget_packages": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_repo.bzl",
+            "ruleClassName": "_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.rules_dotnet_nuget_packages",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.ComponentModel.Annotations\"],\"net6.0\":[\"System.ComponentModel.Annotations\"],\"net7.0\":[\"System.ComponentModel.Annotations\"],\"net8.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.2\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.1\":[\"System.ComponentModel.Annotations\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.ComponentModel.Annotations\"],\"netstandard2.0\":[\"System.ComponentModel.Annotations\"],\"netstandard2.1\":[\"System.ComponentModel.Annotations\"]},\"framework_list\":[],\"id\":\"McMaster.Extensions.CommandLineUtils\",\"name\":\"McMaster.Extensions.CommandLineUtils\",\"sha512\":\"sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.5.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"name\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"name\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"name\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"name\":\"Newtonsoft.Json\",\"sha512\":\"sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"name\":\"NuGet.Commands\",\"sha512\":\"sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Frameworks\"],\"net451\":[\"NuGet.Frameworks\"],\"net452\":[\"NuGet.Frameworks\"],\"net46\":[\"NuGet.Frameworks\"],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"name\":\"NuGet.Common\",\"sha512\":\"sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Common\"],\"net451\":[\"NuGet.Common\"],\"net452\":[\"NuGet.Common\"],\"net46\":[\"NuGet.Common\"],\"net461\":[\"NuGet.Common\"],\"net462\":[\"NuGet.Common\"],\"net47\":[\"NuGet.Common\"],\"net471\":[\"NuGet.Common\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"name\":\"NuGet.Configuration\",\"sha512\":\"sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"name\":\"NuGet.Credentials\",\"sha512\":\"sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"name\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"name\":\"NuGet.Frameworks\",\"sha512\":\"sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"name\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"name\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"name\":\"Nuget.Packaging\",\"sha512\":\"sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Nuget.Packaging.Core\",\"name\":\"Nuget.Packaging.Core\",\"sha512\":\"sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"name\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"name\":\"NuGet.Protocol\",\"sha512\":\"sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"name\":\"NuGet.Resolver\",\"sha512\":\"sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"name\":\"NuGet.Versioning\",\"sha512\":\"sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"NETStandard.Library\"],\"net6.0\":[\"NETStandard.Library\"],\"net7.0\":[\"NETStandard.Library\"],\"net8.0\":[\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[\"NETStandard.Library\"],\"netstandard2.1\":[\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnit\",\"name\":\"NUnit\",\"sha512\":\"sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[\"NUnit\"],\"net40\":[\"NUnit\"],\"net403\":[\"NUnit\"],\"net45\":[\"NUnit\"],\"net451\":[\"NUnit\"],\"net452\":[\"NUnit\"],\"net46\":[\"NUnit\"],\"net461\":[\"NUnit\"],\"net462\":[\"NUnit\"],\"net47\":[\"NUnit\"],\"net471\":[\"NUnit\"],\"net472\":[\"NUnit\"],\"net48\":[\"NUnit\"],\"net5.0\":[\"NUnit\",\"NETStandard.Library\"],\"net6.0\":[\"NUnit\",\"NETStandard.Library\"],\"net7.0\":[\"NUnit\",\"NETStandard.Library\"],\"net8.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.5\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.6\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.1\":[\"NUnit\",\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnitLite\",\"name\":\"NUnitLite\",\"sha512\":\"sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Annotations\",\"name\":\"System.ComponentModel.Annotations\",\"sha512\":\"sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"name\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"name\":\"System.Formats.Asn1\",\"sha512\":\"sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"name\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"name\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"name\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              },
+              "framework_list": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              }
+            }
+          },
+          "nuget.nuget.commands.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "5.10.0",
+              "sha512": "sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg=="
+            }
+          },
+          "nuget.nuget.common.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "5.10.0",
+              "sha512": "sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.nuget.librarymodel.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "5.10.0",
+              "sha512": "sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg=="
+            }
+          },
+          "nuget.nuget.resolver.v5.10.0": {
+            "bzlFile": "@@rules_dotnet~//dotnet/private/rules/nuget:nuget_archive.bzl",
+            "ruleClassName": "nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "5.10.0",
+              "sha512": "sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg=="
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_dotnet~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet~",
+            "local_config_platform",
+            "local_config_platform"
+          ],
+          [
+            "rules_dotnet~",
+            "rules_dotnet",
+            "rules_dotnet~"
+          ]
+        ]
       }
     },
     "@@rules_dotnet~//dotnet/private/sdk/apphost_packs:dotnet.apphost_packs_extension.bzl%apphost_packs_extension": {
@@ -7782,312 +10415,6 @@
             "rules_dotnet~",
             "rules_dotnet",
             "rules_dotnet~"
-          ]
-        ]
-      }
-    },
-    "@@rules_go~//go:extensions.bzl%go_sdk": {
-      "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "etq/3rkpZZF/56Gr7yFomA9M5v8WZFKFjPtFsdmzo54=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "go_linux_arm64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "linux",
-              "goarch": "arm64",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.6",
-              "strip_prefix": "go"
-            }
-          },
-          "go_linux_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "linux",
-              "goarch": "amd64",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.6",
-              "strip_prefix": "go"
-            }
-          },
-          "go_darwin_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "darwin",
-              "goarch": "amd64",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.6",
-              "strip_prefix": "go"
-            }
-          },
-          "go_windows_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "windows",
-              "goarch": "amd64",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.6",
-              "strip_prefix": "go"
-            }
-          },
-          "go_host_compatible_sdk_label": {
-            "bzlFile": "@@rules_go~//go/private:extensions.bzl",
-            "ruleClassName": "host_compatible_toolchain",
-            "attributes": {
-              "toolchain": "@go_darwin_arm64//:ROOT"
-            }
-          },
-          "rules_go__download_0_darwin_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1"
-            }
-          },
-          "go_darwin_arm64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "darwin",
-              "goarch": "arm64",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.6",
-              "strip_prefix": "go"
-            }
-          },
-          "go_toolchains": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_multiple_toolchains",
-            "attributes": {
-              "prefixes": [
-                "_0000_go_darwin_amd64_",
-                "_0001_go_darwin_arm64_",
-                "_0002_go_linux_amd64_",
-                "_0003_go_linux_arm64_",
-                "_0004_go_windows_amd64_",
-                "_0005_go_default_sdk_",
-                "_0006_rules_go__download_0_darwin_amd64_",
-                "_0007_rules_go__download_0_linux_amd64_",
-                "_0008_rules_go__download_0_linux_arm64_",
-                "_0009_rules_go__download_0_windows_amd64_",
-                "_0010_rules_go__download_0_windows_arm64_"
-              ],
-              "geese": [
-                "darwin",
-                "darwin",
-                "linux",
-                "linux",
-                "windows",
-                "",
-                "darwin",
-                "linux",
-                "linux",
-                "windows",
-                "windows"
-              ],
-              "goarchs": [
-                "amd64",
-                "arm64",
-                "amd64",
-                "arm64",
-                "amd64",
-                "",
-                "amd64",
-                "amd64",
-                "arm64",
-                "amd64",
-                "arm64"
-              ],
-              "sdk_repos": [
-                "go_darwin_amd64",
-                "go_darwin_arm64",
-                "go_linux_amd64",
-                "go_linux_arm64",
-                "go_windows_amd64",
-                "go_default_sdk",
-                "rules_go__download_0_darwin_amd64",
-                "rules_go__download_0_linux_amd64",
-                "rules_go__download_0_linux_arm64",
-                "rules_go__download_0_windows_amd64",
-                "rules_go__download_0_windows_arm64"
-              ],
-              "sdk_types": [
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote",
-                "remote"
-              ],
-              "sdk_versions": [
-                "1.21.6",
-                "1.21.6",
-                "1.21.6",
-                "1.21.6",
-                "1.21.6",
-                "1.21.1",
-                "1.21.1",
-                "1.21.1",
-                "1.21.1",
-                "1.21.1",
-                "1.21.1"
-              ]
-            }
-          },
-          "io_bazel_rules_nogo": {
-            "bzlFile": "@@rules_go~//go/private:nogo.bzl",
-            "ruleClassName": "go_register_nogo",
-            "attributes": {
-              "nogo": "@io_bazel_rules_go//:default_nogo",
-              "includes": [
-                "'@@//:__subpackages__'"
-              ],
-              "excludes": []
-            }
-          },
-          "rules_go__download_0_windows_arm64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1"
-            }
-          },
-          "rules_go__download_0_linux_arm64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1"
-            }
-          },
-          "go_default_sdk": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "experiments": [],
-              "patches": [],
-              "patch_strip": 0,
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1",
-              "strip_prefix": "go"
-            }
-          },
-          "rules_go__download_0_linux_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1"
-            }
-          },
-          "rules_go__download_0_windows_amd64": {
-            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
-            "ruleClassName": "go_download_sdk_rule",
-            "attributes": {
-              "goos": "",
-              "goarch": "",
-              "sdks": {},
-              "urls": [
-                "https://dl.google.com/go/{}"
-              ],
-              "version": "1.21.1"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features~",
-            "bazel_features_globals",
-            "bazel_features~~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~",
-            "bazel_features_version",
-            "bazel_features~~version_extension~bazel_features_version"
-          ],
-          [
-            "rules_go~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_go~",
-            "io_bazel_rules_go",
-            "rules_go~"
-          ],
-          [
-            "rules_go~",
-            "io_bazel_rules_go_bazel_features",
-            "bazel_features~"
           ]
         ]
       }
@@ -15587,6 +17914,34 @@
             "rules_swift~",
             "build_bazel_rules_swift",
             "rules_swift~"
+          ]
+        ]
+      }
+    },
+    "@@upb~//:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "aGnO/HqVtCmRLEQWGCuKp7jwX+lCh/nc3/hI3clfwD8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "utf8_range": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/protocolbuffers/utf8_range/archive/de0b4a8ff9b5d4c98108bdfe723291a33c52c54f.zip"
+              ],
+              "strip_prefix": "utf8_range-de0b4a8ff9b5d4c98108bdfe723291a33c52c54f",
+              "sha256": "5da960e5e5d92394c809629a03af3c7709d2d3d0ca731dacb3a9fb4bf28f7702"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "upb~",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }


### PR DESCRIPTION
As @jayconrod noted in EngFlow/engflow#21551, in rules_go 0.47.1:

> ...the go_sdk extension automatically instantiates go_download_sdk
> repositories for common remote platforms...

Hence the removal of GO_PLATFORMS and the individual go_sdk.download() calls. These are replaced by a single go_sdk.download() call that sets the Go version per:

- https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md#go-sdks