### PR TITLE
Fix `bazel test //swift:tests` via Bzlmod ordering

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,13 +48,25 @@ http_archive(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(
     name = "protobuf",
     version = "23.1",
     repo_name = "com_google_protobuf",
 )
+
+# Per the instructions from:
+# https://github.com/bazelbuild/apple_support?tab=readme-ov-file#bazel-7-setup
+#
+# If you also depend on `rules_cc`, `apple_support` must come _above_ `rules_cc`
+# in your `MODULE.bazel` or `WORKSPACE` file because Bazel selects toolchains
+# based on which is registered first.
+bazel_dep(
+    name = "apple_support",
+    version = "1.15.1",
+    repo_name = "build_bazel_apple_support",
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
 
 # https://github.com/googleapis/googleapis/pull/855
 # https://github.com/bazelbuild/bazel-central-registry/pull/1699
@@ -77,12 +89,6 @@ pip.parse(
 use_repo(pip, "pip")
 
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
-
-bazel_dep(
-    name = "apple_support",
-    version = "1.15.1",
-    repo_name = "build_bazel_apple_support",
-)
 
 bazel_dep(name = "rules_dotnet", version = "0.15.1")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -16066,6 +16066,166 @@
           ]
         ]
       }
+    },
+    "@@rules_swift~//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "Cmw0SWMEF+W7yHokTa/RRl3v7uDPKysmnNQ6hvKeA30=",
+        "usagesDigest": "Bxpjq7dEoQ6itfQLt8YOa+X+mqBZ+FWDDiSlD7pLoho=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_grpc_grpc_swift": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@rules_swift~//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "bzlFile": "@@rules_swift~//swift/internal:swift_autoconfiguration.bzl",
+            "ruleClassName": "swift_autoconfiguration",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift~",
+            "build_bazel_rules_swift",
+            "rules_swift~"
+          ]
+        ]
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ build and test software with the EngFlow Remote Execution service.
   - [bazelbuild/rules_swift: Migrate to platforms/toolchains API #3][8]
   - [bazelbuild/rules_swift: Auto-download Linux toolchains when possible #4][9]
 
-
-
 ## Local execution
 
 Make sure that you can build and run the tests in the language of your choice
@@ -101,7 +99,7 @@ needed. For instance:
 #
 # - Depending on your cluster configuration, replace remote_linux_64 with
 #   remote_macos_x64 or remote_windows_x64.
-build:engflow --config=engflow_common                                            
+build:engflow --config=engflow_common
 build:engflow --config=remote_linux_x64
 
 # Configuration for your trial cluster
@@ -141,7 +139,6 @@ build --config=engflow
   bazel build //swift:tests
   ```
 
-
 ### Testing on remote
 
 - `java`, `python`, `scala`, and `typescript`:
@@ -161,7 +158,6 @@ build --config=engflow
   ```sh
   bazel test //swift:tests
   ```
-
 
 ## `engflowapis` execution
 


### PR DESCRIPTION
Also removes extra whitespace and blank lines from README.md.

I inadvertently broke Swift builds and tests in #317 because I added a `bazel_dep()` for `rules_cc` _before_ the one for `apple_support`. This restores the proper order.

FWIW, building or testing `//swift:tests` remotely still doesn't seem to work. It hangs on `--config=remote_macos_x64`, and fails on `--config=remote_linux_x64` with:

```txt
ERROR: .../external/rules_swift~~non_module_deps~build_bazel_rules_swift_local_config/BUILD:9:22:
  in xcode_swift_toolchain rule
  @@rules_swift~~non_module_deps~build_bazel_rules_swift_local_config//:toolchain:

Traceback (most recent call last):
  File ".../external/rules_swift~/swift/internal/xcode_swift_toolchain.bzl",
    line 641, column 21, in _xcode_swift_toolchain_impl
      env = _xcode_env(target_triple = target_triple, xcode_config = xcode_config)
  File ".../external/rules_swift~/swift/internal/xcode_swift_toolchain.bzl",
    line 539, column 34, in _xcode_env
      _bazel_apple_platform(target_triple),
  File ".../external/rules_swift~/swift/internal/xcode_swift_toolchain.bzl",
    line 101, column 34, in _bazel_apple_platform
      return _TRIPLE_OS_TO_PLATFORM[(
Error: key ("linux", "gnu") not found in dictionary

ERROR: .../external/rules_swift~~non_module_deps~build_bazel_rules_swift_local_config/BUILD:9:22:
Analysis of target '@@rules_swift~~non_module_deps~build_bazel_rules_swift_local_config//:toolchain' failed
```