### PR TITLE
Add link to blog post from runfiles/README.md

### DIFF
--- a/runfiles/README.md
+++ b/runfiles/README.md
@@ -1,7 +1,7 @@
 # EngFlow Runfiles Libraries Demo
 
-This is an example repository for an upcoming EngFlow blog post, &quot;Migrating
-to Bazel Modules (a.k.a. Bzlmod) - Repo Names and Runfiles&quot;.
+This is the example code for the EngFlow blog post &quot;[Migrating to Bazel
+Modules (a.k.a. Bzlmod) - Repo Names and Runfiles][blog].&quot;
 
 - `engflow` contains the main repository of the example
 - `frobozz` is a separate Bazel module representing an external dependency
@@ -14,3 +14,5 @@ bazel run //:runfiles_demo
 bazel build //:runfiles_genrule_demo &&
     cat bazel-bin/demo_output.txt
 ```
+
+[blog]: https://blog.engflow.com/2024/08/09/migrating-to-bazel-modules-aka-bzlmod---repo-names-and-runfiles/


### PR DESCRIPTION
The blog post "Migrating to Bazel Modules (a.k.a. Bzlmod) - Repo Names and Runfiles" is now live:

- https://blog.engflow.com/2024/08/09/migrating-to-bazel-modules-aka-bzlmod---repo-names-and-runfiles/