### PR TITLE
Migrating to CI Runners AX-591

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,11 +10,9 @@ build:engflow_common --experimental_inmemory_dotd_files
 build:engflow_common --experimental_inmemory_jdeps_files
 build:engflow_common --incompatible_strict_action_env=true
 build:engflow_common --remote_timeout=3600
-build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:engflow_common --java_runtime_version=remotejdk_11
-build:engflow_common --java_language_version=11
 build:engflow_common --grpc_keepalive_time=30s
 build:engflow_common --legacy_important_outputs=false
+build:engflow_common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 # Options for continuous testing.
 build:ci --color=yes
@@ -25,6 +23,8 @@ build:ci --test_output=summary
 build:ci --show_progress_rate_limit=2.0
 build:ci --nobuild_runfile_links
 build:ci --keep_going
+build:ci --java_runtime_version=remotejdk_11
+build:ci --java_language_version=11
 
 # Additional clang toolchain options for automatically configured toolchains.
 build --cxxopt="-std=c++14"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,20 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: linux
-            arch: x64
-            os_distribution: debian
-            os_version: 11
-            revision: d04e89854b3931f4aaced77aa3a2fcad5834b3a6
-            remote_execution: 'false'
-
-          - os: linux
-            arch: x64
-            os_distribution: debian
-            os_version: 11
-            revision: d04e89854b3931f4aaced77aa3a2fcad5834b3a6
-            remote_execution: 'true'
-
           - os: macos
             arch: x64
             os_distribution: monterey
@@ -77,5 +63,42 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           OS: ${{ matrix.os }}
+          REMOTE_EXECUTION: ${{ matrix.remote_execution }}
+        run: python3 infra/test-all.py
+
+  ci-runners-test-matrix:
+    runs-on:
+      - self-hosted
+      - "os=linux"
+      - "arch=x64"
+      - "remote_execution=${{ matrix.remote_execution }}"
+      - "engflow-container-image=docker://645088952840.dkr.ecr.eu-west-1.amazonaws.com/engflow-ci/debian11-dind-x64@sha256:604855f1ecd6edad3f45f513ed0112b9e8e32589871133767a1a51944b07f487"
+      - "engflow-pool=ci_sysbox_x64"
+      - "engflow-runtime=sysbox-runc"
+      - "engflow-runner-id=${{ github.repository_id }}_ci-runners-test-matrix_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - remote_execution: 'false'
+
+          - remote_execution: 'true'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up authentication
+        shell: bash
+        run: cp infra/bazelrc .bazelrc.user
+
+      - name: Generate python requirements lock
+        shell: bash
+        run: bazel run //python:requirements.update
+
+      - name: Build and test
+        env:
+          ARCH: x64
+          OS: linux
           REMOTE_EXECUTION: ${{ matrix.remote_execution }}
         run: python3 infra/test-all.py


### PR DESCRIPTION
https://linear.app/engflow/issue/AX-591/migrate-debian-11-jobs-to-ci-runners

Prerequisite: https://github.com/EngFlow/prod/pull/13635