### PR TITLE
Add link to blog post from canonical names README

### DIFF
--- a/bzlmod/canonical-repo-name-injection/README.md
+++ b/bzlmod/canonical-repo-name-injection/README.md
@@ -1,7 +1,7 @@
-# Canonical Repo Name Injection
+# Canonical Repo Name Injection Demo
 
-This is the example code for the upcoming EngFlow blog post &quot;Migrating to
-Bazel Modules (a.k.a. Bzlmod) - Repo Names, Macros, and Variables.&quot;
+This is the example code for the EngFlow blog post &quot;[Migrating to Bazel
+Modules (a.k.a. Bzlmod) - Repo Names, Macros, and Variables][blog].&quot;
 
 To try it out:
 
@@ -16,3 +16,5 @@ cat bazel-bin/custom-rule-constants.js
 vimdiff bazel-bin/{genrule,custom-rule}-constants.js
 node bazel-bin/repo-dir-check.mjs
 ```
+
+[blog]: https://blog.engflow.com/2024/09/06/migrating-to-bazel-modules-aka-bzlmod---repo-names-macros-and-variables/


### PR DESCRIPTION
The blog post "Migrating to Bazel Modules (a.k.a. Bzlmod) - Repo Names, Macros, and Variables" is now live:

- https://blog.engflow.com/2024/09/06/migrating-to-bazel-modules-aka-bzlmod---repo-names-macros-and-variables/