### PR TITLE
Added first example for benchmark

### DIFF
--- a/example.iml
+++ b/example.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/java" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/java/com/engflow/cycleexample/class_a/BUILD
+++ b/java/com/engflow/cycleexample/class_a/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "class_a",
+    srcs = ["ClassA.java"],
+    deps = [
+        "//java/com/engflow/cycleexample/class_b",
+        "//java/com/engflow/cycleexample/interface_a",
+    ],
+)
+
+java_test(
+    name = "class_a_test",
+    srcs = ["ClassATest.java"],
+    test_class = "cycleexample",
+
+
+    deps = [
+        ":class_a",
+        "//java/com/engflow/cycleexample/class_b:class_b",
+        "//java/com/engflow/cycleexample/class_c:class_c",
+        "//java/com/engflow/cycleexample/interface_a:interface_a",
+    ],
+)

--- a/java/com/engflow/cycleexample/class_a/ClassA.java
+++ b/java/com/engflow/cycleexample/class_a/ClassA.java
@@ -1,0 +1,25 @@
+package com.engflow.cycleexample.class_a;
+
+import com.engflow.cycleexample.class_b.ClassB;
+import com.engflow.cycleexample.interface_a.InterfaceA;
+
+public class ClassA implements InterfaceA {
+    private static final int MAX_CALLS = 10;
+    private int callCount = 0;
+    private ClassB classB;
+
+    public ClassA(ClassB classB) {
+        this.classB = classB;
+    }
+
+    @Override
+    public void methodA() {
+        if (callCount >= MAX_CALLS) {
+            System.out.println("ClassA.methodA() reached max calls");
+            return;
+        }
+        System.out.println("ClassA.methodA()");
+        callCount++;
+        classB.methodB();
+    }
+}

--- a/java/com/engflow/cycleexample/class_a/ClassATest.java
+++ b/java/com/engflow/cycleexample/class_a/ClassATest.java
@@ -1,0 +1,42 @@
+package com.engflow.cycleexample.class_a;
+
+import com.engflow.cycleexample.class_b.ClassB;
+import com.engflow.cycleexample.class_c.ClassC;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class ClassATest {
+    private static class TestClassB extends ClassB {
+        boolean methodBCalled = false;
+
+        public TestClassB(ClassC classC) {
+            super(classC);
+        }
+
+        @Override
+        public void methodB() {
+            methodBCalled = true;
+        }
+    }
+
+    @Test
+    public void testMethodA() {
+        // Create an instance of ClassA
+        ClassA classA = new ClassA(null);
+
+        // Create a ClassC instance with the ClassA object
+        ClassC classC = new ClassC(classA);
+
+        // Create a TestClassB instance with the ClassC object
+        TestClassB testClassB = new TestClassB(classC);
+
+        // Create a new ClassA instance with the TestClassB object
+        classA = new ClassA(testClassB);
+
+        // Call methodA on classA
+        classA.methodA();
+
+        // Verify that methodB on the TestClassB was called
+        assertTrue(testClassB.methodBCalled);
+    }
+}

--- a/java/com/engflow/cycleexample/class_b/BUILD
+++ b/java/com/engflow/cycleexample/class_b/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "class_b",
+    srcs = ["ClassB.java"],
+    deps = [
+        "//java/com/engflow/cycleexample/class_c",
+        "//java/com/engflow/cycleexample/interface_b",
+    ],
+)
+
+java_test(
+    name = "class_b_test",
+    srcs = ["ClassBTest.java"],
+    test_class = "cycleexample",
+    deps = [":class_b",
+            "//java/com/engflow/cycleexample/class_c:class_c",
+            "//java/com/engflow/cycleexample/interface_b:interface_b"],
+)

--- a/java/com/engflow/cycleexample/class_b/ClassB.java
+++ b/java/com/engflow/cycleexample/class_b/ClassB.java
@@ -1,0 +1,18 @@
+package com.engflow.cycleexample.class_b;
+
+import com.engflow.cycleexample.class_c.ClassC;
+import com.engflow.cycleexample.interface_b.InterfaceB;
+
+public class ClassB implements InterfaceB {
+    private ClassC classC;
+
+    public ClassB(ClassC classC) {
+        this.classC = classC;
+    }
+
+    @Override
+    public void methodB() {
+        System.out.println("ClassB.methodB()");
+        classC.methodA();
+    }
+}

--- a/java/com/engflow/cycleexample/class_b/ClassBTest.java
+++ b/java/com/engflow/cycleexample/class_b/ClassBTest.java
@@ -1,0 +1,35 @@
+package com.engflow.cycleexample.class_b;
+
+import com.engflow.cycleexample.class_c.ClassC;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class ClassBTest {
+    private static class TestClassC extends ClassC {
+        boolean methodACalled = false;
+
+        public TestClassC() {
+            super(null);
+        }
+
+        @Override
+        public void methodA() {
+            methodACalled = true;
+        }
+    }
+
+    @Test
+    public void testMethodB() {
+        // Create a TestClassC instance
+        TestClassC testClassC = new TestClassC();
+
+        // Create an instance of ClassB with the TestClassC object
+        ClassB classB = new ClassB(testClassC);
+
+        // Call methodB on classB
+        classB.methodB();
+
+        // Verify that methodA on the TestClassC was called
+        assertTrue(testClassC.methodACalled);
+    }
+}

--- a/java/com/engflow/cycleexample/class_c/BUILD
+++ b/java/com/engflow/cycleexample/class_c/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "class_c",
+    srcs = ["ClassC.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java/com/engflow/cycleexample/interface_a",
+    ],
+)
+
+java_test(
+    name = "class_c_test",
+    srcs = ["ClassCTest.java"],
+    test_class = "cycleexample",
+    deps = [
+        ":class_c",
+        "//java/com/engflow/cycleexample/class_a:class_a",
+    ],
+)

--- a/java/com/engflow/cycleexample/class_c/ClassC.java
+++ b/java/com/engflow/cycleexample/class_c/ClassC.java
@@ -1,0 +1,29 @@
+package com.engflow.cycleexample.class_c;
+
+import com.engflow.cycleexample.interface_a.InterfaceA;
+
+public class ClassC implements InterfaceA {
+    private InterfaceA classA;
+
+    public ClassC(InterfaceA classA) {
+        this.classA = classA;
+    }
+
+    @Override
+    public void methodA() {
+        System.out.println("ClassC.methodA()");
+        if (classA != null) {
+            classA.methodA();
+        } else {
+            System.out.println("classA is null");
+        }
+    }
+
+    public void setClassA(InterfaceA classA) {
+        this.classA = classA;
+    }
+
+    public void methodC() {
+        System.out.println("ClassC.methodC()");
+    }
+}

--- a/java/com/engflow/cycleexample/class_c/ClassCTest.java
+++ b/java/com/engflow/cycleexample/class_c/ClassCTest.java
@@ -1,0 +1,35 @@
+package com.engflow.cycleexample.class_c;
+
+import com.engflow.cycleexample.class_a.ClassA;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class ClassCTest {
+    private static class TestClassA extends ClassA {
+        boolean methodACalled = false;
+
+        public TestClassA() {
+            super(null);
+        }
+
+        @Override
+        public void methodA() {
+            methodACalled = true;
+        }
+    }
+
+    @Test
+    public void testMethodA() {
+        // Create a TestClassA instance
+        TestClassA testClassA = new TestClassA();
+
+        // Create an instance of ClassC with the TestClassA object
+        ClassC classC = new ClassC(testClassA);
+
+        // Call methodA on classC
+        classC.methodA();
+
+        // Verify that methodA on the TestClassA was called
+        assertTrue(testClassA.methodACalled);
+    }
+}

--- a/java/com/engflow/cycleexample/interface_a/BUILD
+++ b/java/com/engflow/cycleexample/interface_a/BUILD
@@ -1,0 +1,5 @@
+java_library(
+    name = "interface_a",
+    srcs = ["InterfaceA.java"],
+    visibility = ["//visibility:public"],
+)

--- a/java/com/engflow/cycleexample/interface_a/InterfaceA.java
+++ b/java/com/engflow/cycleexample/interface_a/InterfaceA.java
@@ -1,0 +1,5 @@
+package com.engflow.cycleexample.interface_a;
+
+public interface InterfaceA {
+    void methodA();
+}

--- a/java/com/engflow/cycleexample/interface_b/BUILD
+++ b/java/com/engflow/cycleexample/interface_b/BUILD
@@ -1,0 +1,5 @@
+java_library(
+    name = "interface_b",
+    srcs = ["InterfaceB.java"],
+    visibility = ["//visibility:public"],
+)

--- a/java/com/engflow/cycleexample/interface_b/InterfaceB.java
+++ b/java/com/engflow/cycleexample/interface_b/InterfaceB.java
@@ -1,0 +1,5 @@
+package com.engflow.cycleexample.interface_b;
+
+public interface InterfaceB {
+    void methodB();
+}

--- a/java/com/engflow/cycleexample/main/BUILD
+++ b/java/com/engflow/cycleexample/main/BUILD
@@ -1,0 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
+java_binary(
+    name = "main",
+    srcs = ["Main.java"],
+    deps = [
+        "//java/com/engflow/cycleexample/class_a",
+        "//java/com/engflow/cycleexample/class_b",
+        "//java/com/engflow/cycleexample/class_c",
+    ],
+    main_class = "cycleexample",
+)

--- a/java/com/engflow/cycleexample/main/Main.java
+++ b/java/com/engflow/cycleexample/main/Main.java
@@ -1,0 +1,18 @@
+package com.engflow.cycleexample.main;
+
+import com.engflow.cycleexample.class_a.ClassA;
+import com.engflow.cycleexample.class_b.ClassB;
+import com.engflow.cycleexample.class_c.ClassC;
+
+public class Main {
+    public static void main(String[] args) {
+        ClassC classC = new ClassC(null);
+        ClassB classB = new ClassB(classC);
+        ClassA classA = new ClassA(classB);
+
+        // Properly initialize classC with classA
+        classC.setClassA(classA);
+
+        classA.methodA();
+    }
+}


### PR DESCRIPTION
This example is meant to test system performance when dealing with a cyclical-like structure implemented through Java interfaces, while avoiding direct cyclical dependencies in the code. By using interfaces and constructor injection, we simulate a cyclic dependency that is handled dynamically at runtime without causing build-time cycles.
ClassA.methodA calls ClassB.methodB. 
ClassB.methodB calls CallC.methodA. 
ClassC, which implements InterfaceA, holds a reference to ClassA through the interface, allowing it to call methodA and complete the cycle.
To prevent infinite recursion and potential memory issues, the program limits the number of recursive methodA() calls, allowing the test to run safely.