### PR TITLE
[macos] update macos runners for ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,17 +35,17 @@ jobs:
       matrix:
         include:
           - os: macos
-            arch: x64
-            os_distribution: monterey
-            os_version: "12"
-            revision: 1ec247a1e93f4980098fc6bb2764bb093b37b3da
+            arch: arm64
+            os_distribution: sonoma
+            os_version: "14"
+            revision: dd17e52a1f04529abb97003e8093d356739980d7
             remote_execution: 'false'
 
           - os: macos
-            arch: x64
-            os_distribution: monterey
-            os_version: "12"
-            revision: 1ec247a1e93f4980098fc6bb2764bb093b37b3da
+            arch: arm64
+            os_distribution: sonoma
+            os_version: "14"
+            revision: dd17e52a1f04529abb97003e8093d356739980d7
             remote_execution: 'true'
 
     steps:


### PR DESCRIPTION
We no longer support legacy x86 mac runners.