### PR TITLE
improve docker image script

### DIFF
--- a/platform/windows_x64/BUILD
+++ b/platform/windows_x64/BUILD
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 load(":windows_cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,7 +12,7 @@ platform(
         "@rules_go//go/toolchain:cgo_off",
     ],
     exec_properties = {
-        "container-image": "docker://645088952840.dkr.ecr.eu-west-1.amazonaws.com/engflow-re/windows-x64:engflow_worker@sha256:6a53c6d5cbc82ca0782e9117482e457a676920227b697de5db90ff53e7afedbe",
+        "container-image": "<YOUR_WINDOWS_CONTAINER_IMAGE_URI>",
         "Pool": "windows",
     },
 )
@@ -35,13 +35,13 @@ toolchain(
 
 cc_toolchain_suite(
     name = "toolchain",
-    target_compatible_with = [
-        "@platforms//os:windows",
-    ],
     toolchains = {
         "x64_windows|msvc": ":msvc_cc_toolchain",
         "x64_windows": ":msvc_cc_toolchain",
     },
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
 )
 
 cc_toolchain(

--- a/platform/windows_x64/docker/build.ps1
+++ b/platform/windows_x64/docker/build.ps1
@@ -14,7 +14,7 @@ Set-StrictMode -Version latest
 # then invokes 'docker build'.
 
 # Verify that this script was run from the repository root.
-if (-not (Test-Path "platform/windows_x64/docker/build.ps1" -Type Leaf) -or -not (Test-Path "WORKSPACE" -Type Leaf)) {
+if (-not (Test-Path "platform/windows_x64/docker/build.ps1" -Type Leaf) -or -not (Test-Path "MODULE.bazel" -Type Leaf)) {
   Write-Error "Run this script from the repository root directory."
 }
 
@@ -22,44 +22,46 @@ if (-not (Test-Path "platform/windows_x64/docker/build.ps1" -Type Leaf) -or -not
 $repoRootDir = Get-Location
 Write-Verbose "repoRootDir $repoRootDir"
 $buildDir = "${repoRootDir}/_build"
-Write-Verbose "Copying files to ${buildDir}..."
-New-Item -Type 'directory' -Path $buildDir
-trap {
-  Set-Location $repoRootDir
-  Remove-Item -Recurse -Force $buildDir
+
+try {
+    Write-Verbose "Copying files to ${buildDir}..."
+    New-Item -Type 'directory' -Path $buildDir
+    Copy-Item 'platform/windows_x64/docker/normalize_os_windows.ps1' $buildDir
+    Copy-Item 'platform/windows_x64/docker/install_jre.ps1' $buildDir
+    Copy-Item 'platform/windows_x64/docker/install_msys2.ps1' $buildDir
+    Copy-Item 'platform/windows_x64/docker/install_python.ps1' $buildDir
+    Copy-Item 'platform/windows_x64/docker/install_vs_build_tools.ps1' $buildDir
+    Copy-Item 'platform/windows_x64/docker/Dockerfile' $buildDir
+
+    # Build the showincludes wrapper binary.
+    # TODO(CUS-81): Remove this after
+    # https://github.com/bazelbuild/bazel/issues/19733 is fixed, and we're upgraded
+    # to a version of Bazel that has the fix.
+    bazel build //infra/msvc_filter_showincludes
+    Copy-Item 'bazel-bin/infra/msvc_filter_showincludes/msvc_filter_showincludes_/msvc_filter_showincludes.exe' $buildDir
+
+    # Build the Docker image.
+    #
+    # Additional memory is needed to install VS build tools. The default 1GB
+    # is not enough.
+    #
+    # Additional storage space is needed, too: the default 20GB is not enough.
+    # Configure C:\ProgramData\docker\config\daemon.json with:
+    #
+    #     "storage-opts": [
+    #       "size=50G"
+    #     ]
+    Write-Verbose "Building docker image..."
+    Set-Location $buildDir
+    docker build `
+      --tag engflow-container-image `
+      --memory '4GB' `
+      .
 }
-Copy-Item 'platform/windows_x64/docker/normalize_os_windows.ps1' $buildDir
-Copy-Item 'platform/windows_x64/docker/install_jre.ps1' $buildDir
-Copy-Item 'platform/windows_x64/docker/install_msys2.ps1' $buildDir
-Copy-Item 'platform/windows_x64/docker/install_python.ps1' $buildDir
-Copy-Item 'platform/windows_x64/docker/install_vs_build_tools.ps1' $buildDir
-Copy-Item 'platform/windows_x64/docker/Dockerfile' $buildDir
-
-# Build the showincludes wrapper binary.
-# TODO(CUS-81): Remove this after
-# https://github.com/bazelbuild/bazel/issues/19733 is fixed, and we're upgraded
-# to a version of Bazel that has the fix.
-bazel build //infra/msvc_filter_showincludes
-Copy-Item 'bazel-bin/infra/msvc_filter_showincludes/msvc_filter_showincludes_/msvc_filter_showincludes.exe' $buildDir
-
-# Build the Docker image.
-#
-# Additional memory is needed to install VS build tools. The default 1GB
-# is not enough.
-#
-# Additional storage space is needed, too: the default 20GB is not enough.
-# Configure C:\ProgramData\docker\config\daemon.json with:
-#
-#     "storage-opts": [
-#       "size=50G"
-#     ]
-Write-Verbose "Building docker image..."
-Set-Location $buildDir
-docker build `
-  --tag engflow-container-image `
-  --memory '4GB' `
-  .
-Set-Location $repoRootDir
-
-# Remove the temporary directory on success.
-Remove-Item -Recurse -Force $buildDir
+finally {
+    # Always return to the original directory and clean up
+    Set-Location $repoRootDir
+    if (Test-Path $buildDir) {
+        Remove-Item -Recurse -Force $buildDir
+    }
+}

--- a/platform/windows_x64/docker/install_vs_build_tools.ps1
+++ b/platform/windows_x64/docker/install_vs_build_tools.ps1
@@ -7,7 +7,7 @@ $InformationPreference = "Continue"
 $global:ProgressPreference = "SilentlyContinue"
 
 Write-Verbose "Installing VS Buildtools (needed for Bazel)..."
-Invoke-WebRequest -Uri "https://storage.googleapis.com/engflow-tools-public/vs_buildtools__859897378.1616711895.exe" -OutFile "c:/vs_buildtools__859897378.1616711895.exe"
+Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile "c:/vs_buildtools.exe"
 $installArgs = @(
   '--quiet',
   '--wait',
@@ -27,5 +27,5 @@ $installArgs = @(
   '--remove',
   'Microsoft.VisualStudio.Component.Windows81SDK'
 )
-Start-Process c:/vs_buildtools__859897378.1616711895.exe -Wait -ArgumentList ($installArgs -join ' ')
-Remove-Item "c:/vs_buildtools__859897378.1616711895.exe" -Force
+Start-Process c:/vs_buildtools.exe -Wait -ArgumentList ($installArgs -join ' ')
+Remove-Item "c:/vs_buildtools.exe" -Force


### PR DESCRIPTION
- Fix error-handling in `trap {}` statement by changing it to a `try...catch`
    - If the script hit an error before `$repoRootDir = Get-Location` was invoked, the error would get masked by another error from within the `trap` handler

```
- InvalidOperation: C:\Users\lgehorsam\example\platform\windows_x64\docker\build.ps1:28:16
Line |
  28 |    Set-Location $repoRootDir
     |                 ~~~~~~~~~~~~
     | The variable '$repoRootDir' cannot be retrieved because it has not been set.
```

- Remove reference to previous windows container image.
- Fix repository root path test
- Change URI where build tools are pulled from.