### PR TITLE
CI: add engflow-run-id label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       - "engflow-pool=ci_sysbox_x64"
       - "engflow-runtime=sysbox-runc"
       - "engflow-runner-id=${{ github.repository_id }}_ci-runners-test-matrix_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}"
+      - "engflow-run-id=${{ github.run_id }}"
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -114,6 +115,7 @@ jobs:
       - "engflow-pool=ci_sysbox_x64"
       - "engflow-runtime=sysbox-runc"
       - "engflow-runner-id=${{ github.repository_id }}_buck2-test_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}"
+      - "engflow-run-id=${{ github.run_id }}"
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
Latest EngFlow version requires it: https://docs.engflow.com/ci-runners/configure-ci-runners-for-github-actions.html#step-6-update-the-labels-in-your-workflow-file