### PR TITLE
CI: use different bento for buck2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
       - self-hosted
       - "os=linux"
       - "arch=x64"
-      - "engflow-bento-name=example-gh-x64"
+      - "engflow-bento-name=example-gh-buck2-x64"
       - "engflow-cluster=glass"
       - "engflow-job-name=ci-runners-test-matrix"
       - "engflow-job-type=${{github.event_name}}-${{github.ref_name}}"


### PR DESCRIPTION
Different than bazel workflows, so we avoid possible problems with warm runs. Bento doesn't yet officially support Buck2.

Proof: https://github.com/EngFlow/example/actions/runs/26567837244/job/78266973641