### PR TITLE
Mac unit tests

### DIFF
--- a/ios/BUILD
+++ b/ios/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_apple//apple:ios.bzl", "ios_application", "ios_ui_test", "ios_unit_test")
+load("@rules_apple//apple:macos.bzl", "macos_unit_test")
 load("@rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
@@ -52,4 +53,16 @@ ios_ui_test(
     runner = "@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     test_host = ":HelloApp",
     deps = [":HelloAppUITestLib"],
+    exec_properties = {
+        "sandboxAllowed": "False",
+    },
+)
+
+macos_unit_test(
+    name = "HelloMacTest",
+    minimum_os_version = "14.0",
+    deps = [":HelloTestLib"],
+    exec_properties = {
+        "sandboxAllowed": "False",
+    },
 )

--- a/ios/HelloTest.swift
+++ b/ios/HelloTest.swift
@@ -1,10 +1,8 @@
-import Testing
+import XCTest
 
-@Suite
-struct HelloTest {
-    @Test
-    func example() {
+class HelloTest: XCTestCase {
+    func testExample() {
         print("Hello from HelloTest")
-        #expect(1 + 1 == 2)
+        XCTAssertEqual(1 + 1, 2)
     }
 }

--- a/ios/kcpasswd.py
+++ b/ios/kcpasswd.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Port of Gavin Brock's Perl kcpassword generator to Python, by Tom Taylor
+# <tom@tomtaylor.co.uk>.
+# Perl version: http://www.brock-family.org/gavin/perl/kcpassword.html
+# https://github.com/timsutton/osx-vm-templates/blob/master/scripts/support/set_kcpassword.py
+
+import getpass
+import sys
+import os
+
+
+def kcpassword(passwd):
+    # The magic 11 bytes - these are just repeated
+    # 0x7D 0x89 0x52 0x23 0xD2 0xBC 0xDD 0xEA 0xA3 0xB9 0x1F
+    key = [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]
+    key_len = len(key)
+
+    passwd = list(bytearray(passwd, "utf8"))
+    # pad passwd length out to an even multiple of key length
+    r = len(passwd) % key_len
+    if (r > 0):
+        passwd = passwd + [0] * (key_len - r)
+
+    for n in range(0, len(passwd), len(key)):
+        for j in range(n, min(n + len(key), len(passwd))):
+            passwd[j] = passwd[j] ^ key[j % key_len]
+
+    return bytearray(passwd)
+
+
+if __name__ == "__main__":
+    secret = getpass.getpass("Autologin user password: ")
+    passwd = kcpassword(secret)
+    fd = os.open('/etc/kcpassword', os.O_WRONLY | os.O_CREAT, 0o600)
+    file = os.fdopen(fd, 'wb')
+    file.write(passwd)
+    file.close()

--- a/platform/macos_arm64/BUILD
+++ b/platform/macos_arm64/BUILD
@@ -13,7 +13,8 @@ platform(
     ],
     exec_properties = {
         "Pool": "macos_arm_m2",
-        "test.sandboxAllowed": "False",  # ios tests need to escape the sandbox in order to correctly reach the simulator service.
+        "sandboxAllowed": "False",
+        #"test.sandboxAllowed": "False",  # ios tests need to escape the sandbox in order to correctly reach the simulator service.
     },
 )
 


### PR DESCRIPTION
Builds on #442.

- converts the test to `XCTest` (using `Testing` was giving me errors, I suspect this is a config issue)
- Adds a helper script to generate passwords (we shouldn't merge this part).

DO NOT MERGE, putting this up for testing.